### PR TITLE
Handle redirects on inertia views

### DIFF
--- a/inertia/http.py
+++ b/inertia/http.py
@@ -81,6 +81,11 @@ def inertia(component):
     @wraps(func)
     def inner(request, *args, **kwargs):
       props = func(request, *args, **kwargs)
+
+      # if something other than a dict is returned, the user probably wants to return a specific response
+      if not isinstance(props, dict):
+        return props
+
       return render(request, component, props)
     
     return inner

--- a/inertia/tests/test_rendering.py
+++ b/inertia/tests/test_rendering.py
@@ -66,6 +66,12 @@ class SubsequentLoadTestCase(InertiaTestCase):
       200
     )
 
+  def test_redirects_from_inertia_views(self):
+    self.assertEqual(
+      self.inertia.get('/inertia-redirect/').status_code,
+      302
+    )
+
 class LazyPropsTestCase(InertiaTestCase):
   def test_lazy_props_are_not_included(self):
     self.assertJSONResponse(

--- a/inertia/tests/testapp/urls.py
+++ b/inertia/tests/testapp/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
   path('lazy/', views.lazy_test),
   path('complex-props/', views.complex_props_test),
   path('share/', views.share_test),
+  path('inertia-redirect/', views.inertia_redirect_test),
 ]

--- a/inertia/tests/testapp/views.py
+++ b/inertia/tests/testapp/views.py
@@ -24,6 +24,10 @@ def redirect_test(request):
   return redirect(empty_test)
 
 @inertia('TestComponent')
+def inertia_redirect_test(request):
+  return redirect(empty_test)
+
+@inertia('TestComponent')
 def props_test(request):
   return {
     'name': 'Brandon',


### PR DESCRIPTION
I generally always use the `@inertia` decorator for my inertia views, but using the decorator prevents you from returning other types of responses like redirects. This change will allow this behavior that currently results in an error:

```python
@inertia('SomeComponent')
def some_view(request):
   if request.method == 'POST':
      return redirect('/somewhere-else/')
```