### PR TITLE
Automatically include and document CSRF tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,25 @@ your frontend of choice, just replace the contents of `entry.js` with [this file
 
 You can also check out the official Inertia docs at https://inertiajs.com/. 
 
+### CSRF
+
+Django's CSRF tokens are tightly coupled with rendering templates so Inertia Django automatically handles adding the CSRF cookie for you to each Inertia response. Because the default names Django users for the CSRF headers don't match Axios (the Javascript request library Inertia uses), we'll need to either modify Axios's defaults OR Django's settings. 
+
+**You only need to choose one of the following options, just pick whichever makes the most sense to you!**
+
+In your `entry.js` file
+```javascript
+axios.defaults.xsrfHeaderName = "X-CSRFToken"
+axios.defaults.xsrfCookieName = "csrftoken"
+```
+OR
+
+In your Django `settings.py` file
+```python
+CSRF_HEADER_NAME = 'HTTP_X_XSRF_TOKEN'
+CSRF_COOKIE_NAME = 'XSRF-TOKEN'
+```
+
 ## Usage
 
 ### Responses

--- a/inertia/middleware.py
+++ b/inertia/middleware.py
@@ -1,6 +1,7 @@
 from .settings import settings
 from django.contrib import messages
 from django.http import HttpResponse
+from django.middleware.csrf import get_token
 
 class InertiaMiddleware:
   def __init__(self, get_response):
@@ -11,6 +12,10 @@ class InertiaMiddleware:
 
     if not self.is_inertia_request(request):
       return response
+
+    # Inertia requests don't ever render templates, so they skip the typical Django
+    # CSRF path. We'll manually add a CSRF token for every request here.
+    get_token(request)
 
     if self.is_non_post_redirect(request, response):
       response.status_code = 303

--- a/inertia/tests/test_rendering.py
+++ b/inertia/tests/test_rendering.py
@@ -98,3 +98,9 @@ class ShareTestCase(InertiaTestCase):
       self.inertia.get('/share/'),
       inertia_page('share', props={'name': 'Brandon', 'position': 'goalie', 'number': 29})
     )
+
+class CSRFTestCase(InertiaTestCase):
+  def test_that_csrf_inclusion_is_automatic(self):
+    response = self.inertia.get('/props/')
+
+    self.assertIsNotNone(response.cookies.get('csrftoken'))


### PR DESCRIPTION
Because Django tightly couples its CSRF implementation with rendering templates we need to manually include the CSRF token in inertia responses. This PR automatically adds the CSRF token to all outgoing inertia responses.

I can't think of a downside to doing this so there's no opt-out at the moment.

Resolves #14 
Resolves #9 
Resolves #8 