### PR TITLE
CSRF for non inertia requests

### DIFF
--- a/inertia/middleware.py
+++ b/inertia/middleware.py
@@ -10,12 +10,12 @@ class InertiaMiddleware:
   def __call__(self, request):
     response = self.get_response(request)
 
-    if not self.is_inertia_request(request):
-      return response
-
     # Inertia requests don't ever render templates, so they skip the typical Django
     # CSRF path. We'll manually add a CSRF token for every request here.
     get_token(request)
+
+    if not self.is_inertia_request(request):
+      return response
 
     if self.is_non_post_redirect(request, response):
       response.status_code = 303

--- a/inertia/tests/test_rendering.py
+++ b/inertia/tests/test_rendering.py
@@ -104,6 +104,7 @@ class CSRFTestCase(InertiaTestCase):
     response = self.inertia.get('/props/')
 
     self.assertIsNotNone(response.cookies.get('csrftoken'))
+
   def test_that_csrf_is_included_even_on_initial_page_load(self):
     response = self.client.get('/props/')
 

--- a/inertia/tests/test_rendering.py
+++ b/inertia/tests/test_rendering.py
@@ -104,3 +104,7 @@ class CSRFTestCase(InertiaTestCase):
     response = self.inertia.get('/props/')
 
     self.assertIsNotNone(response.cookies.get('csrftoken'))
+  def test_that_csrf_is_included_even_on_initial_page_load(self):
+    response = self.client.get('/props/')
+
+    self.assertIsNotNone(response.cookies.get('csrftoken'))


### PR DESCRIPTION
## Changes

**Problem description**

When requesting a page for the initial page load, e.g. not an Inertia request from the browser with 'X-Inertia' header, the csrf token isn't set in the response. The token isn't set, because even in the initial page load the typical Django CSRF path isn't called as well.

Example: When requesting the login-page for the first time, no csrf token is set and the post to django fails.

**Solution**

In the inertia middleware the `get_token()` is called before checking for the existance of 'X-Inertia' header.