### PR TITLE
Replace hardcoded component in test with argument

### DIFF
--- a/inertia/test.py
+++ b/inertia/test.py
@@ -55,7 +55,7 @@ class InertiaTestCase(BaseInertiaTestCase, TestCase):
 
 def inertia_page(url, component='TestComponent', props={}, template_data={}):
   return {
-    'component': 'TestComponent',
+    'component': component,
     'props': props,
     'url': f'http://testserver/{url}/',
     'version': settings.INERTIA_VERSION,


### PR DESCRIPTION
The `inertia_page` method currently doesn't use the component that's given as an argument. This commit fixes that.