### PR TITLE
Fixed 303 redirect for PUT method

### DIFF
--- a/inertia/middleware.py
+++ b/inertia/middleware.py
@@ -26,7 +26,7 @@ class InertiaMiddleware:
     return response
 
   def is_non_post_redirect(self, request, response):
-    return self.is_redirect_request(response) and request.method in ['POST', 'PATCH', 'DELETE']
+    return self.is_redirect_request(response) and request.method in ['PUT', 'PATCH', 'DELETE']
 
   def is_inertia_request(self, request):
     return 'X-Inertia' in request.headers

--- a/inertia/tests/test_middleware.py
+++ b/inertia/tests/test_middleware.py
@@ -16,11 +16,13 @@ class MiddlewareTestCase(InertiaTestCase):
     self.assertEqual(response.headers['X-Inertia-Location'], 'http://testserver/empty/')
 
   def test_redirect_status(self):
-    for http_method in ['post', 'patch', 'delete']:
+    response = self.inertia.post('/redirect/')
+    self.assertEqual(response.status_code, 302)
+
+    for http_method in ['put', 'patch', 'delete']:
       response = getattr(self.inertia, http_method)('/redirect/')
 
       self.assertEqual(response.status_code, 303)
-
 
   def test_a_request_not_from_inertia_is_ignored(self):
     response = self.client.get('/empty/',


### PR DESCRIPTION
According to the [documentation](https://inertiajs.com/redirects#303-response-code) (and the [laravel](https://github.com/inertiajs/inertia-laravel/blob/master/src/Middleware.php#L102C3-L102C3) and [rails](https://github.com/inertiajs/inertia-rails/blob/master/lib/inertia_rails/middleware.rb#L48C8-L48C8) projects), the 303 redirect should happen for PUT, PATCH, and DELETE methods. However, the code is currently handling POST instead of PUT.