### PR TITLE
Implement form validation & redirect back with errors

### DIFF
--- a/inertia/__init__.py
+++ b/inertia/__init__.py
@@ -1,3 +1,4 @@
 from .http import inertia, render
 from .utils import lazy
 from .share import share
+from .validation import inertia_validate, InertiaValidationError

--- a/inertia/middleware.py
+++ b/inertia/middleware.py
@@ -2,12 +2,22 @@ from .settings import settings
 from django.contrib import messages
 from django.http import HttpResponse
 from django.middleware.csrf import get_token
+from .validation import InertiaValidationError, VALIDATION_ERRORS_SESSION_KEY
+from .share import share
 
 class InertiaMiddleware:
   def __init__(self, get_response):
     self.get_response = get_response
-  
+
   def __call__(self, request):
+    validation_errors =  request.session.get(VALIDATION_ERRORS_SESSION_KEY, None)
+
+    if self.is_inertia_get_request(request) and validation_errors is not None:
+      request.session.pop(VALIDATION_ERRORS_SESSION_KEY)
+      request.session.modified = True
+      # Must be shared before rendering the response
+      share(request, errors=validation_errors)
+
     response = self.get_response(request)
 
     # Inertia requests don't ever render templates, so they skip the typical Django
@@ -25,11 +35,21 @@ class InertiaMiddleware:
 
     return response
 
+  def process_exception(self, request, exception):
+    if isinstance(exception, InertiaValidationError):
+      errors = {field: errors[0] for field, errors in exception.errors.items()}
+      request.session[VALIDATION_ERRORS_SESSION_KEY] = errors
+      request.session.modified = True
+      return exception.redirect
+
   def is_non_post_redirect(self, request, response):
     return self.is_redirect_request(response) and request.method in ['PUT', 'PATCH', 'DELETE']
 
   def is_inertia_request(self, request):
     return 'X-Inertia' in request.headers
+
+  def is_inertia_get_request(self, request):
+    return request.method == "GET" and self.is_inertia_request(request)
 
   def is_redirect_request(self, response):
     return response.status_code in [301, 302]

--- a/inertia/tests/test_rendering.py
+++ b/inertia/tests/test_rendering.py
@@ -109,3 +109,22 @@ class CSRFTestCase(InertiaTestCase):
     response = self.client.get('/props/')
 
     self.assertIsNotNone(response.cookies.get('csrftoken'))
+
+class FormValidationTestCase(InertiaTestCase):
+  def test_inertia_receives_errors_prop(self):
+    submit_invalid_form_response = self.inertia.post(
+      path='/form/',
+      data={'invalid': 'data'},
+      follow=True,
+    )
+
+    self.assertJSONResponse(
+      submit_invalid_form_response,
+      inertia_page('form', props={
+        'test': 'props',
+        'errors': {
+          'str_field': 'This field is required.',
+          'num_field': 'This field is required.',
+        }
+      })
+    )

--- a/inertia/tests/testapp/forms.py
+++ b/inertia/tests/testapp/forms.py
@@ -1,0 +1,5 @@
+from django import forms
+
+class TestForm(forms.Form):
+    str_field = forms.CharField(max_length=100, required=True)
+    num_field = forms.IntegerField(min_value=20, required=True)

--- a/inertia/tests/testapp/urls.py
+++ b/inertia/tests/testapp/urls.py
@@ -11,4 +11,5 @@ urlpatterns = [
   path('complex-props/', views.complex_props_test),
   path('share/', views.share_test),
   path('inertia-redirect/', views.inertia_redirect_test),
+  path('form/', views.form_test),
 ]

--- a/inertia/tests/testapp/views.py
+++ b/inertia/tests/testapp/views.py
@@ -1,14 +1,15 @@
 from django.http.response import HttpResponse
 from django.shortcuts import redirect
 from django.utils.decorators import decorator_from_middleware
-from inertia import inertia, render, lazy, share
+from inertia import inertia, render, lazy, share, InertiaValidationError
+from .forms import TestForm
 
 class ShareMiddleware:
   def __init__(self, get_response):
     self.get_response = get_response
 
   def process_request(self, request):
-    share(request, 
+    share(request,
       position=lambda: 'goalie',
       number=29,
     )
@@ -62,3 +63,16 @@ def share_test(request):
   return {
     'name': 'Brandon',
   }
+
+def form_test(request):
+  # TODO: request.POST only works with the test HTTP client, Inertia sends
+  # JSON from the browser by default, not multipart/form-data
+  form = TestForm(request.POST)
+
+  if request.method == "GET":
+    return render(request, 'TestComponent', {'test': 'props'})
+
+  if not form.is_valid():
+    raise InertiaValidationError(form.errors, redirect(form_test))
+
+  return redirect(empty_test)

--- a/inertia/validation.py
+++ b/inertia/validation.py
@@ -1,0 +1,23 @@
+from typing import Union
+
+from django.forms import Form
+from django.forms.utils import ErrorDict
+from django.http import HttpResponsePermanentRedirect, HttpResponseRedirect
+
+VALIDATION_ERRORS_SESSION_KEY = "_inertia_validation_errors"
+
+InertiaRedirect = Union[HttpResponseRedirect, HttpResponsePermanentRedirect]
+
+
+class InertiaValidationError(Exception):
+  def __init__(self, errors: ErrorDict, redirect: InertiaRedirect):
+    super().__init__()
+    self.redirect = redirect
+    self.errors = errors
+
+
+def inertia_validate(form: Form, redirect: InertiaRedirect):
+  if not form.is_valid():
+    raise InertiaValidationError(form.errors, redirect)
+
+  return form.cleaned_data


### PR DESCRIPTION
Following up on https://github.com/inertiajs/inertia-django/issues/30, here's a basic implementation of [Inertia Validation](https://inertiajs.com/validation). Quoting the docs:

> If there are server-side validation errors, you don't return those errors as a 422 JSON response. Instead, you redirect (server-side) the user back to the form page they were previously on, flashing the validation errors in the session.

> In order for your server-side validation errors to be available client-side, your server-side framework must share them via the errors prop.

That's what the code does, when `not form.is_valid()` you can raise `InertiaValidationError` and this library handles flashing validation errors in the session, redirecting and passing the `error` prop to Inertia. For now you must explicitly provide the "previous" URL where to user should be redirected, since it's not stored anywhere.

Basic usage example:

```python
# views.py

import json
from inertia import render, InertiaValidationError
from django.shortcuts import redirect

class ExampleFormView(View):
    def get(self, request):
        return render(request, "SomeForm")

    def post(self, request):
        form = SomeForm(json.loads(request.body))

        if not form.is_valid():
            raise InertiaValidationError(form.errors, redirect("form"))

        # use form.cleaned_data here...

        return redirect("some_other_route")

# urls.py

urlpatterns = [path("/form", ExampleFormView.as_view(), name="form")]
```
Instead of raising the error manually you can also call the `inertia_validate` helper, which will raise the error automatically:

```python
form = SomeForm(json.loads(request.body))
cleaned_data = inertia_validate(form, redirect("form"))
```

In some cases you don't actually know where the user should be redirected because the form might be located in a pop-up that you can trigger from multiple places or something similar. For example, imagine a "Login" button in the navbar that opens a side panel with a login form. For now, the best option is to use the HTTP [`Referer`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer) header to handle such cases:

```python
if not form.is_valid():
    raise InertiaValidationError(form.errors, redirect(request.headers["Referer"])
```

In order to avoid redirecting manually we could change the API so that you pass the request and an optional `fallback`:

```python
if not form.is_valid():
    raise InertiaValidationError(request, form.errors, fallback=redirect("some_route"))
```

This would try to redirect to `request.headers["Referer"]` if present, otherwise use the fallback, which could be set to `"/"` by default.

Technically, the `Referer` header is optional so we shouldn't rely 100% on it, Laravel for example stores the "previous" URL in the session on every `GET` request to its server. Here's some pseudocode based on [Laravel 10.x implementation](https://github.com/laravel/framework/blob/507ce9b28bce4b5e4140c28943092ca38e9a52e4/src/Illuminate/Session/Middleware/StartSession.php#L200):

```python
if (
    request.method == "GET"
    and not request.headers.get("X-Requested-With") == "XMLHttpRequest"
):
    request.session["_previous_url"] = request.build_absolute_uri()
```

But I don't think implementing this is necessary, because in practice all major browsers will send the `Referer` header and even [Laravel favors `Referer` over everything else](https://github.com/laravel/framework/blob/507ce9b28bce4b5e4140c28943092ca38e9a52e4/src/Illuminate/Routing/UrlGenerator.php#L162).