### PR TITLE
Add support for Django 5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-django = "^4.0"
+django = ">=4"
 requests = "^2"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Currently, Poetry is restricting Django to only the v4 series. This uncaps the version, allowing for 4 and up.

As a side note, I noticed the poetry lock wasn't being committed to the repo, was that intentional? As far as I understand, that should get tracked with the project, that's what makes the virtual envs reproducible.