### PR TITLE
Add examples to Readme and add Django Svelte Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ class ExampleTestCase(InertiaTestCase):
 The inertia test helper also includes a special `inertia` client that pre-sets the inertia headers
 for you to simulate an inertia response. You can access and use it just like the normal client with commands like `self.inertia.get('/events/')`. When using the inertia client, inertia custom assertions **are not** enabled though, so only use it if you want to directly assert against the json response.
 
+## Examples
+
+- [Django Svelte Template](https://github.com/pmdevita/Django-Svelte-Template) - A Django template and example project demonstrating Inertia with Svelte and SSR.
+
 ## Thank you
 
 A huge thank you to the community members who have worked on InertiaJS for Django before us. Parts of this repo were particularly inspired by [Andres Vargas](https://github.com/zodman) and [Samuel Girardin](https://github.com/girardinsamuel). Additional thanks to Andres for the Pypi project.


### PR DESCRIPTION
Meant to do this forever ago, #22 . Finally added the examples section to the Readme