### PR TITLE
Set `Vary` header to `X-Inertia` (protocol update)

### DIFF
--- a/inertia/http.py
+++ b/inertia/http.py
@@ -63,7 +63,7 @@ def render(request, component, props={}, template_data={}):
     return JsonResponse(
       data=page_data(),
       headers={
-        'Vary': 'Accept',
+        'Vary': 'X-Inertia',
         'X-Inertia': 'true',
       },
       encoder=settings.INERTIA_JSON_ENCODER,


### PR DESCRIPTION
The [protocol page](https://inertiajs.com/the-protocol#inertia-responses) has been updated, indicating that `Vary` should be `X-Inertia` from now.