### PR TITLE
Add GitHub workflow to run pytest when a branch is pushed

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,20 @@
+name: Unit tests
+
+on: [push]
+
+jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install deps
+        run: |
+          python -m pip install -U pip
+          pip install poetry
+          poetry install
+      - name: Run python tests
+        run: |
+          poetry run pytest


### PR DESCRIPTION
This PR adds a GitHub workflow to run pytest on push for better CI/CD cycle. 

## Problem

Even though there are test code, they should be run manually when testing.

## Changes

Adds a GitHub workflow to run tests automatically. It does the following when a branch is pushed.

1. Install poetry and dependencies
2. Run pytest
