### PR TITLE
Add location function to redirect to a non-Inertia URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,21 @@ def inertia_share(get_response):
   return middleware
 ```
 
+### External Redirects
+
+It is possible to redirect to an external website, or even another non-Inertia endpoint in your app while handling an Inertia request. 
+This can be accomplished using a server-side initiated `window.location` visit via the `location` method:
+
+```python
+from inertia import location
+
+def external():
+    return location("http://foobar.com/")
+```
+
+It will generate a `409 Conflict` response and include the destination URL in the `X-Inertia-Location` header. 
+When this response is received client-side, Inertia will automatically perform a `window.location = url` visit.
+
 ### Lazy Props
 On the front end, Inertia supports the concept of "partial reloads" where only the props requested
 are returned by the server. Sometimes, you may want to use this flow to avoid processing a particularly slow prop on the intial load. In this case, you can use `Lazy props`. Lazy props aren't evaluated unless they're specifically requested by name in a partial reload.

--- a/inertia/__init__.py
+++ b/inertia/__init__.py
@@ -1,3 +1,3 @@
-from .http import inertia, render
+from .http import inertia, render, location
 from .utils import lazy
 from .share import share

--- a/inertia/http.py
+++ b/inertia/http.py
@@ -1,4 +1,5 @@
-from django.http import JsonResponse
+from http import HTTPStatus
+from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render as base_render
 from .settings import settings
 from json import dumps as json_encode
@@ -80,6 +81,11 @@ def render(request, component, props={}, template_data={}):
     'page': json_encode(page_data(), cls=settings.INERTIA_JSON_ENCODER),
     **template_data,
   })
+
+def location(location):
+    return HttpResponse('', status=HTTPStatus.CONFLICT, headers={
+      'X-Inertia-Location': location,
+    })
 
 def inertia(component):
   def decorator(func):

--- a/inertia/middleware.py
+++ b/inertia/middleware.py
@@ -2,6 +2,7 @@ from .settings import settings
 from django.contrib import messages
 from django.http import HttpResponse
 from django.middleware.csrf import get_token
+from .http import location
 
 class InertiaMiddleware:
   def __init__(self, get_response):
@@ -42,6 +43,4 @@ class InertiaMiddleware:
 
   def force_refresh(self, request):
     messages.get_messages(request).used = False
-    return HttpResponse('', status=409, headers={
-      'X-Inertia-Location': request.build_absolute_uri(),
-    })
+    return location(request.build_absolute_uri())

--- a/inertia/tests/test_middleware.py
+++ b/inertia/tests/test_middleware.py
@@ -30,3 +30,11 @@ class MiddlewareTestCase(InertiaTestCase):
     )
 
     self.assertEqual(response.status_code, 200)
+
+  def test_external_redirect_status(self):
+    response = self.inertia.post('/external-redirect/')
+    self.assertEqual(response.status_code, 409)
+    self.assertIn("X-Inertia-Location", response.headers)
+    self.assertEqual(
+      "http://foobar.com/", response.headers["X-Inertia-Location"]
+    )

--- a/inertia/tests/testapp/urls.py
+++ b/inertia/tests/testapp/urls.py
@@ -11,4 +11,5 @@ urlpatterns = [
   path('complex-props/', views.complex_props_test),
   path('share/', views.share_test),
   path('inertia-redirect/', views.inertia_redirect_test),
+  path('external-redirect/', views.external_redirect_test),
 ]

--- a/inertia/tests/testapp/views.py
+++ b/inertia/tests/testapp/views.py
@@ -1,7 +1,7 @@
 from django.http.response import HttpResponse
 from django.shortcuts import redirect
 from django.utils.decorators import decorator_from_middleware
-from inertia import inertia, render, lazy, share
+from inertia import inertia, render, lazy, share, location
 
 class ShareMiddleware:
   def __init__(self, get_response):
@@ -26,6 +26,9 @@ def redirect_test(request):
 @inertia('TestComponent')
 def inertia_redirect_test(request):
   return redirect(empty_test)
+
+def external_redirect_test(request):
+  return location("http://foobar.com/")
 
 @inertia('TestComponent')
 def props_test(request):


### PR DESCRIPTION
This PR adds a helper function to handle a redirect to a non-Inertia URL.

## Problem

The Laravel adapter has `Inertia::location` method to deal with [external redirects](https://inertiajs.com/redirects#external-redirects), but it looks that the Django adapter does not have such method.

## Changes

 - Added `location` function to `inertia.http`
 - Added a test for external redirect

The changes are mostly inspired by `inertia_location` method of [flask-inertia](https://github.com/j0ack/flask-inertia).