### PR TITLE
Add support for encrypt and clear history

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,46 @@ Inertia Django ships with a custom JsonEncoder at `inertia.utils.InertiaJsonEnco
 `DjangoJSONEncoder` with additional logic to handle encoding models and Querysets. If you have other json 
 encoding logic you'd prefer, you can set a new JsonEncoder via the settings.
 
+### History Encryption
+
+Inertia.js supports [history encryption](https://inertiajs.com/history-encryption) to protect sensitive data in the browser's history state. This is useful when your pages contain sensitive information that shouldn't be stored in plain text in the browser's history. This feature requires HTTPS since it relies on `window.crypto.subtle` which is only available in secure contexts.
+
+You can enable history encryption globally via the `INERTIA_ENCRYPT_HISTORY` setting in your `settings.py`:
+
+```python
+INERTIA_ENCRYPT_HISTORY = True
+```
+
+For more granular control, you can enable encryption on specific views:
+
+```python
+from inertia import encrypt_history, inertia
+
+@inertia('TestComponent')
+def encrypt_history_test(request):
+    encrypt_history(request)
+    return {}
+
+# If you have INERTIA_ENCRYPT_HISTORY = True but want to disable encryption for specific views:
+@inertia('PublicComponent')
+def public_view(request):
+    encrypt_history(request, False)  # Explicitly disable encryption for this view
+    return {}
+```
+
+When users log out, you might want to clear the history to ensure no sensitive data can be accessed. You can do this by extending the logout view:
+
+```python
+from inertia import clear_history
+from django.contrib.auth import views as auth_views
+
+class LogoutView(auth_views.LogoutView):
+    def dispatch(self, request, *args, **kwargs):
+        response = super().dispatch(request, *args, **kwargs)
+        clear_history(request)
+        return response
+```
+
 ### SSR 
 
 #### Backend
@@ -168,6 +208,7 @@ INERTIA_LAYOUT = 'layout.html' # required and has no default
 INERTIA_JSON_ENCODER = CustomJsonEncoder # defaults to inertia.utils.InertiaJsonEncoder
 INERTIA_SSR_URL = 'http://localhost:13714' # defaults to http://localhost:13714
 INERTIA_SSR_ENABLED = False # defaults to False
+INERTIA_ENCRYPT_HISTORY = False # defaults to False
 ```
 
 ## Testing

--- a/inertia/http.py
+++ b/inertia/http.py
@@ -57,15 +57,20 @@ def render(request, component, props={}, template_data={}):
 
   def page_data():
     encrypt_history = getattr(request, INERTIA_REQUEST_ENCRYPT_HISTORY, settings.INERTIA_ENCRYPT_HISTORY)
+    if not isinstance(encrypt_history, bool):
+      raise TypeError(f"Expected boolean for encrypt_history, got {type(encrypt_history).__name__}")
+
     clear_history = request.session.pop(INERTIA_SESSION_CLEAR_HISTORY, False)
+    if not isinstance(clear_history, bool):
+      raise TypeError(f"Expected boolean for clear_history, got {type(clear_history).__name__}")
 
     return {
       'component': component,
       'props': build_props(),
       'url': request.build_absolute_uri(),
       'version': settings.INERTIA_VERSION,
-      'encryptHistory': bool(encrypt_history),
-      'clearHistory': bool(clear_history),
+      'encryptHistory': encrypt_history,
+      'clearHistory': clear_history,
     }
 
   if 'X-Inertia' in request.headers:

--- a/inertia/http.py
+++ b/inertia/http.py
@@ -7,6 +7,9 @@ from functools import wraps
 import requests
 from .utils import LazyProp
 
+INERTIA_REQUEST_ENCRYPT_HISTORY = "_inertia_encrypt_history"
+INERTIA_SESSION_CLEAR_HISTORY = "_inertia_clear_history"
+
 def render(request, component, props={}, template_data={}):
   def is_a_partial_render():
     return 'X-Inertia-Partial-Data' in request.headers and request.headers.get('X-Inertia-Partial-Component', '') == component
@@ -53,11 +56,16 @@ def render(request, component, props={}, template_data={}):
     })
 
   def page_data():
+    encrypt_history = getattr(request, INERTIA_REQUEST_ENCRYPT_HISTORY, settings.INERTIA_ENCRYPT_HISTORY)
+    clear_history = request.session.pop(INERTIA_SESSION_CLEAR_HISTORY, False)
+
     return {
       'component': component,
       'props': build_props(),
       'url': request.build_absolute_uri(),
       'version': settings.INERTIA_VERSION,
+      'encryptHistory': bool(encrypt_history),
+      'clearHistory': bool(clear_history),
     }
 
   if 'X-Inertia' in request.headers:
@@ -86,6 +94,12 @@ def location(location):
     return HttpResponse('', status=HTTPStatus.CONFLICT, headers={
       'X-Inertia-Location': location,
     })
+
+def encrypt_history(request, value=True):
+  setattr(request, INERTIA_REQUEST_ENCRYPT_HISTORY, value)
+
+def clear_history(request):
+  request.session[INERTIA_SESSION_CLEAR_HISTORY] = True
 
 def inertia(component):
   def decorator(func):

--- a/inertia/settings.py
+++ b/inertia/settings.py
@@ -8,6 +8,7 @@ class InertiaSettings:
   INERTIA_JSON_ENCODER = InertiaJsonEncoder
   INERTIA_SSR_URL = 'http://localhost:13714'
   INERTIA_SSR_ENABLED = False
+  INERTIA_ENCRYPT_HISTORY = False
   
   def __getattribute__(self, name):
     try:

--- a/inertia/test.py
+++ b/inertia/test.py
@@ -59,6 +59,8 @@ def inertia_page(url, component='TestComponent', props={}, template_data={}):
     'props': props,
     'url': f'http://testserver/{url}/',
     'version': settings.INERTIA_VERSION,
+    'encryptHistory': False,
+    'clearHistory': False,
   }
 
 def inertia_div(*args, **kwargs):

--- a/inertia/tests/test_history.py
+++ b/inertia/tests/test_history.py
@@ -30,3 +30,10 @@ class MiddlewareTestCase(InertiaTestCase):
     response = self.client.get('/clear-history-redirect/', follow=True)
     self.assertRedirects(response, '/empty/')
     assert self.page()['clearHistory'] is True
+
+  def test_raises_type_error(self):
+    with self.assertRaisesMessage(TypeError, 'Expected boolean for encrypt_history, got str'):
+      self.client.get('/encrypt-history-type-error/')
+
+    with self.assertRaisesMessage(TypeError, 'Expected boolean for clear_history, got str'):
+      self.client.get('/clear-history-type-error/')

--- a/inertia/tests/test_history.py
+++ b/inertia/tests/test_history.py
@@ -1,0 +1,32 @@
+from inertia.http import encrypt_history
+from inertia.test import InertiaTestCase
+from django.test import override_settings
+from django.test.client import RequestFactory
+from inertia.tests.testapp.views import empty_test
+
+
+class MiddlewareTestCase(InertiaTestCase):
+  def test_encrypt_history_setting(self):
+    self.client.get('/empty/')
+    assert self.page()['encryptHistory'] is False
+
+    with override_settings(INERTIA_ENCRYPT_HISTORY=True):
+      self.client.get('/empty/')
+      assert self.page()['encryptHistory'] is True
+
+  def test_encrypt_history(self):
+    self.client.get('/encrypt-history/')
+    assert self.page()['encryptHistory'] is True
+
+    with override_settings(INERTIA_ENCRYPT_HISTORY=True):
+      self.client.get('/no-encrypt-history/')
+      assert self.page()['encryptHistory'] is False
+
+  def test_clear_history(self):
+    self.client.get('/clear-history/')
+    assert self.page()['clearHistory'] is True
+
+  def test_clear_history_redirect(self):
+    response = self.client.get('/clear-history-redirect/', follow=True)
+    self.assertRedirects(response, '/empty/')
+    assert self.page()['clearHistory'] is True

--- a/inertia/tests/testapp/urls.py
+++ b/inertia/tests/testapp/urls.py
@@ -12,4 +12,8 @@ urlpatterns = [
   path('share/', views.share_test),
   path('inertia-redirect/', views.inertia_redirect_test),
   path('external-redirect/', views.external_redirect_test),
+  path('encrypt-history/', views.encrypt_history_test),
+  path('no-encrypt-history/', views.encrypt_history_false_test),
+  path('clear-history/', views.clear_history_test),
+  path('clear-history-redirect/', views.clear_history_redirect_test),
 ]

--- a/inertia/tests/testapp/urls.py
+++ b/inertia/tests/testapp/urls.py
@@ -14,6 +14,8 @@ urlpatterns = [
   path('external-redirect/', views.external_redirect_test),
   path('encrypt-history/', views.encrypt_history_test),
   path('no-encrypt-history/', views.encrypt_history_false_test),
+  path('encrypt-history-type-error/', views.encrypt_history_type_error_test),
   path('clear-history/', views.clear_history_test),
   path('clear-history-redirect/', views.clear_history_redirect_test),
+  path('clear-history-type-error/', views.clear_history_type_error_test),
 ]

--- a/inertia/tests/testapp/views.py
+++ b/inertia/tests/testapp/views.py
@@ -2,6 +2,7 @@ from django.http.response import HttpResponse
 from django.shortcuts import redirect
 from django.utils.decorators import decorator_from_middleware
 from inertia import inertia, render, lazy, share, location
+from inertia.http import clear_history, encrypt_history
 
 class ShareMiddleware:
   def __init__(self, get_response):
@@ -65,3 +66,24 @@ def share_test(request):
   return {
     'name': 'Brandon',
   }
+
+@inertia('TestComponent')
+def encrypt_history_test(request):
+  encrypt_history(request)
+  return {}
+
+@inertia('TestComponent')
+def encrypt_history_false_test(request):
+  encrypt_history(request, False)
+  return {}
+
+@inertia('TestComponent')
+def clear_history_test(request):
+  clear_history(request)
+  return {}
+
+@inertia('TestComponent')
+def clear_history_redirect_test(request):
+  clear_history(request)
+  return redirect(empty_test)
+

--- a/inertia/tests/testapp/views.py
+++ b/inertia/tests/testapp/views.py
@@ -2,7 +2,7 @@ from django.http.response import HttpResponse
 from django.shortcuts import redirect
 from django.utils.decorators import decorator_from_middleware
 from inertia import inertia, render, lazy, share, location
-from inertia.http import clear_history, encrypt_history
+from inertia.http import INERTIA_SESSION_CLEAR_HISTORY, clear_history, encrypt_history
 
 class ShareMiddleware:
   def __init__(self, get_response):
@@ -78,6 +78,11 @@ def encrypt_history_false_test(request):
   return {}
 
 @inertia('TestComponent')
+def encrypt_history_type_error_test(request):
+  encrypt_history(request, "foo")
+  return {}
+
+@inertia('TestComponent')
 def clear_history_test(request):
   clear_history(request)
   return {}
@@ -87,3 +92,7 @@ def clear_history_redirect_test(request):
   clear_history(request)
   return redirect(empty_test)
 
+@inertia('TestComponent')
+def clear_history_type_error_test(request):
+  request.session[INERTIA_SESSION_CLEAR_HISTORY] = "foo"
+  return {}


### PR DESCRIPTION
This pull request adds support for the history encryption feature in Inertia 2.

It introduces a new setting called `INERTIA_ENCRYPT_HISTORY ` to set `encryptHistory` globally.

Further more it introduces two new functions to manage `encryptHistory` and `clearHistory` on request basis.

### Examples:

Set encrypt history:

```python
@inertia('TestComponent')
def encrypt_history_test(request):
    encrypt_history(request)
    return {}
```

Logout view:

```python
class LogoutView(auth_views.LogoutView):
    def dispatch(self, request, *args, **kwargs):
        response = super().dispatch(request, *args, **kwargs)
        # The session gets flushed during logout.
        # Calling clear_history after the logout results in desired behavior.
        clear_history(request)
        return response
```

#51 