### PR TITLE
Add InertiaMeta for automatic serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,30 @@ def inertia_share(get_response):
     return get_response(request)
   return middleware
 ```
+### Prop Serialization
+
+Unlike Rails and Laravel, Django does not handle converting objects to JSON by default so Inertia Django offers two different ways to handle prop serialization.
+
+#### InertiaJsonEncoder
+
+The default behavior is via the InertiaJsonEncoder. The InertiaJsonEncoder is a barebones implementation
+that extends the DjangoJSONEncoder with the ability to handle QuerySets and models. Models are JSON encoded
+via Django's `model_to_dict` method excluding the field `password`. This method has limitations though, as
+`model_to_dict` does not include fields where editable=False (such as automatic timestamps).
+
+#### InertiaMeta
+
+Starting in Inertia Django v1.2, Inertia Django supports an InertiaMeta nested class. Similar to Django Rest Framework's serializers, any class (not just models) can contain an InertiaMeta class which can specify how that class should be serialized to JSON. At this time, in only supports `fields`, but this may be extended in future versions.
+
+```python
+class User(models.Model):
+  name = models.CharField(max_length=255)
+  password = models.CharField(max_length=255)
+  created_at = models.DateField(auto_now_add=True)
+
+  class InertiaMeta:
+    fields = ('name', 'created_at')
+```
 
 ### External Redirects
 

--- a/inertia/tests/test_encoder.py
+++ b/inertia/tests/test_encoder.py
@@ -47,9 +47,8 @@ class InertiaJsonEncoderTestCase(TestCase):
                     "created_at": "2022-10-31T10:13:01",
                 }
             ),
-            self.encode(sport)
+            self.encode(sport),
         )
-
 
     def test_it_handles_querysets(self):
         User(

--- a/inertia/tests/test_encoder.py
+++ b/inertia/tests/test_encoder.py
@@ -3,7 +3,7 @@ from json import dumps
 
 from django.test import TestCase
 
-from inertia.tests.testapp.models import User
+from inertia.tests.testapp.models import Sport, User
 from inertia.utils import InertiaJsonEncoder
 
 
@@ -30,6 +30,26 @@ class InertiaJsonEncoderTestCase(TestCase):
             ),
             self.encode(user),
         )
+
+    def test_it_handles_inertia_meta_fields(self):
+        sport = Sport(
+            id=3,
+            name="Hockey",
+            season="Winter",
+            created_at=datetime(2022, 10, 31, 10, 13, 1),
+        )
+
+        self.assertEqual(
+            dumps(
+                {
+                    "id": 3,
+                    "name": "Hockey",
+                    "created_at": "2022-10-31T10:13:01",
+                }
+            ),
+            self.encode(sport)
+        )
+
 
     def test_it_handles_querysets(self):
         User(

--- a/inertia/tests/testapp/models.py
+++ b/inertia/tests/testapp/models.py
@@ -6,3 +6,12 @@ class User(models.Model):
     password = models.CharField(max_length=255)
     birthdate = models.DateField()
     registered_at = models.DateTimeField()
+    created_at = models.DateField(auto_now_add=True)
+
+class Sport(models.Model):
+    name = models.CharField(max_length=255)
+    season = models.CharField(max_length=255)
+    created_at = models.DateField(auto_now_add=True)
+
+    class InertiaMeta:
+        fields = ('id', 'name', 'created_at')

--- a/inertia/tests/testapp/models.py
+++ b/inertia/tests/testapp/models.py
@@ -8,10 +8,11 @@ class User(models.Model):
     registered_at = models.DateTimeField()
     created_at = models.DateField(auto_now_add=True)
 
+
 class Sport(models.Model):
     name = models.CharField(max_length=255)
     season = models.CharField(max_length=255)
     created_at = models.DateField(auto_now_add=True)
 
     class InertiaMeta:
-        fields = ('id', 'name', 'created_at')
+        fields = ("id", "name", "created_at")

--- a/inertia/utils.py
+++ b/inertia/utils.py
@@ -14,7 +14,7 @@ def model_to_dict(model):
 
 class InertiaJsonEncoder(DjangoJSONEncoder):
     def default(self, value):
-        if hasattr(value.__class__, 'InertiaMeta'):
+        if hasattr(value.__class__, "InertiaMeta"):
             return {
                 field: getattr(value, field)
                 for field in value.__class__.InertiaMeta.fields

--- a/inertia/utils.py
+++ b/inertia/utils.py
@@ -14,6 +14,12 @@ def model_to_dict(model):
 
 class InertiaJsonEncoder(DjangoJSONEncoder):
     def default(self, value):
+        if hasattr(value.__class__, 'InertiaMeta'):
+            return {
+                field: getattr(value, field)
+                for field in value.__class__.InertiaMeta.fields
+            }
+
         if isinstance(value, models.Model):
             return model_to_dict(value)
 


### PR DESCRIPTION
This PR adds the concept of `InertiaMeta` as suggested by @scajanus in #65 

```python
class User(models.Model):
  name = models.CharField(max_length=255)
  password = models.CharField(max_length=255)
  created_at = models.DateField(auto_now_add=True)

  class InertiaMeta:
    fields = ('name', 'created_at')
```

Will result in the props output of a User instance being

```json
{
  "name": "Brandon",
  "created_at": "2025-01-25T10:13:01"
}
```

Because of the implementation, `InertiaMeta` can also be used on any class, not just models!
