### PR TITLE
Actually allow modifying JSON encoder

### DIFF
--- a/inertia/http.py
+++ b/inertia/http.py
@@ -160,7 +160,7 @@ class BaseInertiaResponseMixin:
 
 
 class InertiaResponse(BaseInertiaResponseMixin, HttpResponse):
-    json_encoder = settings.INERTIA_JSON_ENCODER
+    json_encoder = None
 
     def __init__(
         self,
@@ -178,7 +178,10 @@ class InertiaResponse(BaseInertiaResponseMixin, HttpResponse):
         self.template_data = template_data or {}
         _headers = headers or {}
 
-        data = json_encode(self.page_data(), cls=self.json_encoder)
+        data = json_encode(
+            self.page_data(),
+            cls=self.json_encoder or settings.INERTIA_JSON_ENCODER,
+        )
 
         if self.request.is_inertia():
             _headers = {


### PR DESCRIPTION
If `inertia.http` is imported early enough, `InertiaResponse.json_encoder` got forcibly assigned to the default and was never read from settings.

This moves resolving the actual encoder to when the response is initialized.