### PR TITLE
Don't fail serializing querysets of non-models

### DIFF
--- a/inertia/tests/test_encoder.py
+++ b/inertia/tests/test_encoder.py
@@ -7,17 +7,21 @@ from inertia.tests.testapp.models import Sport, User
 from inertia.utils import InertiaJsonEncoder
 
 
+def make_brandon() -> User:
+    return User(
+        name="Brandon",
+        password="something-top-secret",
+        birthdate=date(1987, 2, 15),
+        registered_at=datetime(2022, 10, 31, 10, 13, 1),
+    )
+
+
 class InertiaJsonEncoderTestCase(TestCase):
     def setUp(self):
         self.encode = lambda obj: dumps(obj, cls=InertiaJsonEncoder)
 
     def test_it_handles_models_with_dates_and_removes_passwords(self):
-        user = User(
-            name="Brandon",
-            password="something-top-secret",
-            birthdate=date(1987, 2, 15),
-            registered_at=datetime(2022, 10, 31, 10, 13, 1),
-        )
+        user = make_brandon()
 
         self.assertEqual(
             dumps(
@@ -51,12 +55,7 @@ class InertiaJsonEncoderTestCase(TestCase):
         )
 
     def test_it_handles_querysets(self):
-        User(
-            name="Brandon",
-            password="something-top-secret",
-            birthdate=date(1987, 2, 15),
-            registered_at=datetime(2022, 10, 31, 10, 13, 1),
-        ).save()
+        make_brandon().save()
 
         self.assertEqual(
             dumps(
@@ -70,4 +69,13 @@ class InertiaJsonEncoderTestCase(TestCase):
                 ]
             ),
             self.encode(User.objects.all()),
+        )
+
+
+    def test_it_handles_non_model_querysets(self):
+        user = make_brandon()
+        user.save()
+        self.assertEqual(
+            self.encode(User.objects.values_list("name", flat=True)),
+            self.encode([user.name]),
         )

--- a/inertia/utils.py
+++ b/inertia/utils.py
@@ -24,7 +24,10 @@ class InertiaJsonEncoder(DjangoJSONEncoder):
             return model_to_dict(value)
 
         if isinstance(value, QuerySet):
-            return [model_to_dict(model) for model in value]
+            return [
+                (model_to_dict(obj) if isinstance(value.model, models.Model) else obj)
+                for obj in value
+            ]
 
         return super().default(value)
 


### PR DESCRIPTION
This makes it possible to serialize e.g. a `.dates()` queryset – or just a `.values()` one as well.