### PR TITLE
Allow AlwaysProp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,7 +160,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # because this is a package, we don't want to commit the lock file
 poetry.lock

--- a/inertia/http.py
+++ b/inertia/http.py
@@ -92,14 +92,20 @@ class BaseInertiaResponseMixin:
             **(self.request.inertia),
             **self.props,
         }
+        delete_queue = []
 
-        for key in list(_props.keys()):
+        for key, value in _props.items():
+            if isinstance(value, AlwaysProp):
+                continue
+
             if self.request.is_a_partial_render(self.component):
                 if key not in self.request.partial_keys():
-                    del _props[key]
+                    delete_queue.append(key)
             else:
                 if isinstance(_props[key], IgnoreOnFirstLoadProp):
-                    del _props[key]
+                    delete_queue.append(key)
+
+        _props = {key: val for key, val in _props.items() if key not in delete_queue}
 
         return deep_transform_callables(_props)
 

--- a/inertia/prop_classes.py
+++ b/inertia/prop_classes.py
@@ -19,6 +19,10 @@ class IgnoreOnFirstLoadProp:
     pass
 
 
+class AlwaysProp(CallableProp):
+    pass
+
+
 class OptionalProp(CallableProp, IgnoreOnFirstLoadProp):
     pass
 

--- a/inertia/utils.py
+++ b/inertia/utils.py
@@ -5,7 +5,7 @@ from django.db import models
 from django.db.models.query import QuerySet
 from django.forms.models import model_to_dict as base_model_to_dict
 
-from .prop_classes import DeferredProp, MergeProp, OptionalProp
+from .prop_classes import DeferredProp, MergeProp, OptionalProp, AlwaysProp
 
 
 def model_to_dict(model):
@@ -39,6 +39,10 @@ def lazy(prop):
         stacklevel=2,
     )
     return optional(prop)
+
+
+def always(prop):
+    return AlwaysProp(prop)
 
 
 def optional(prop):


### PR DESCRIPTION
The Laravel adapter has a `Inertia::always` method to always include data (on standard visits and on partial reloads without being explicitly requested). This pull request implements it.