### PR TITLE
Add self.headers field to InertiaResponse to enable customizability

### DIFF
--- a/inertia/http.py
+++ b/inertia/http.py
@@ -186,7 +186,7 @@ class InertiaResponse(BaseInertiaResponseMixin, HttpResponse):
         self.component = component
         self.props = props or {}
         self.template_data = template_data or {}
-        _headers = headers or {}
+        self.headers = headers or {}
 
         data = json_encode(
             self.page_data(),
@@ -194,8 +194,8 @@ class InertiaResponse(BaseInertiaResponseMixin, HttpResponse):
         )
 
         if self.request.is_inertia():
-            _headers = {
-                **_headers,
+            self.headers = {
+                **self.headers,
                 "Vary": "X-Inertia",
                 "X-Inertia": "true",
                 "Content-Type": "application/json",
@@ -207,7 +207,7 @@ class InertiaResponse(BaseInertiaResponseMixin, HttpResponse):
         super().__init__(
             *args,
             content=content,
-            headers=_headers,
+            headers=self.headers,
             **kwargs,
         )
 


### PR DESCRIPTION
Hello, I am very excited, this is my first contribution to open source software (so please have patience with me)

Reason for this MR is that I have created my custom Middleware to pass django messages through inertia (code below), but the headers is only value in the InertiaResponse that is not saved as an instance field, so I can't recreate from one response another one.

But if you have any better ideas, that would be even better.

EDIT: simplified approach in my code example

```
class DataShareMiddleware(object):
	def __init__(self, get_response):
		self.get_response = get_response

	def collect_messages(self, request) -> list:
		messages = []
		for msg in get_messages(request):
			message = {
				"message": msg.message,
				"level": msg.level,
				"tags": msg.tags,
				"extra_tags": msg.extra_tags,
				"level_tag": msg.level_tag,
			}
			messages.append(message)
		return messages
	
	def __call__(self, request):
		"""
		Collecting messages before running the view works out of the box
		the issue comes when the view adds messages, since share method
		works with request object, share method doesn't work after the execution
		of the view

		Workaround: collect messages after the view
                run share function		
		and then recreate the response with edited request
		"""
		# collectin message before view works out of the box
                # messages = self.collect_messages(request)
                # share(request, messages=messages)
		response = self.get_response(request)
		# collecting messages after view is problematic, since inertia's share function
		# works with request object
		if hasattr(response, 'request') and hasattr(response.request, 'inertia'):
                       messages = self.collect_messages(request)
                       if messages:
			    share(request, messages=messages)
			    # for now doesn't work with headers, cuz headers are not stored
			    # as property in InertiaResponse
			    # TODO: create MR for inertia-django to add headers to add headers field to the response
                            # so I can access it with response.header
			    response = InertiaResponse(
				request,
				response.component,
				response.props,
				response.template_data
			    )
	        return response
```