### PR TITLE
Make InertiaRequest inherit from HttpRequest (#78)

### DIFF
--- a/inertia/http.py
+++ b/inertia/http.py
@@ -27,18 +27,19 @@ INERTIA_SSR_TEMPLATE = "inertia_ssr.html"
 
 class InertiaRequest(HttpRequest):
     def __init__(self, request):
-        self.request = request
-
-    def __getattr__(self, name):
-        return getattr(self.request, name)
+        super().__init__()
+        self.__dict__.update(request.__dict__)
 
     @property
     def headers(self):
-        return self.request.headers
+        return super().headers
 
     @property
     def inertia(self):
-        return self.request.inertia.all() if hasattr(self.request, "inertia") else {}
+        inertia_attr = self.__dict__.get("inertia")
+        return (
+            inertia_attr.all() if inertia_attr and hasattr(inertia_attr, "all") else {}
+        )
 
     def is_a_partial_render(self, component):
         return (
@@ -58,7 +59,7 @@ class InertiaRequest(HttpRequest):
     def should_encrypt_history(self):
         return validate_type(
             getattr(
-                self.request,
+                self,
                 INERTIA_REQUEST_ENCRYPT_HISTORY,
                 settings.INERTIA_ENCRYPT_HISTORY,
             ),

--- a/inertia/http.py
+++ b/inertia/http.py
@@ -3,7 +3,7 @@ from http import HTTPStatus
 from json import dumps as json_encode
 
 from django.core.exceptions import ImproperlyConfigured
-from django.http import HttpResponse
+from django.http import HttpRequest, HttpResponse
 from django.template.loader import render_to_string
 
 from .helpers import deep_transform_callables, validate_type
@@ -25,7 +25,7 @@ INERTIA_TEMPLATE = "inertia.html"
 INERTIA_SSR_TEMPLATE = "inertia_ssr.html"
 
 
-class InertiaRequest:
+class InertiaRequest(HttpRequest):
     def __init__(self, request):
         self.request = request
 

--- a/inertia/http.py
+++ b/inertia/http.py
@@ -31,10 +31,6 @@ class InertiaRequest(HttpRequest):
         self.__dict__.update(request.__dict__)
 
     @property
-    def headers(self):
-        return super().headers
-
-    @property
     def inertia(self):
         inertia_attr = self.__dict__.get("inertia")
         return (


### PR DESCRIPTION
Follow up on #78. Makes `InertiaRequest` inherit from Django's `HttpRequest` in order to improve compatibility with other libraries. 