### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.2.0"
 description = "Django adapter for the InertiaJS framework"
 authors = [{name="Brandon Shar", email="brandon@bellawatt.com"}]
 license = "MIT"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 repository = "https://github.com/inertiajs/inertia-django"
 homepage = "https://github.com/inertiajs/inertia-django"


### PR DESCRIPTION
Python 3.9 will be [EOF in October](https://devguide.python.org/versions/).

Supporting 3.9 also blocks type hinting #85, as `django-stubs` [require 3.10 as a minimum version](https://github.com/typeddjango/django-stubs/blob/f596ee55859111cb6d3fad05a4107015ba2393a9/pyproject.toml#L12), and poetry will not resolve the dependency, even in dev.