### PR TITLE
Fix the Next Page link on the Introduction page in the docs

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,3 +1,10 @@
+---
+pref: false
+next:
+  text: 'Server-side'
+  link: '/guide/server-side-setup'
+---
+
 # Introduction
 
 Welcome to the documentation for [inertia-django](https://github.com/inertiajs/inertia-django) adapter for [Django](https://www.djangoproject.com/) and [Inertia.js](https://inertiajs.com/).

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,5 +1,5 @@
 ---
-pref: false
+prev: false
 next:
   text: 'Server-side'
   link: '/guide/server-side-setup'


### PR DESCRIPTION
The problem: the current link to the next page on https://inertiajs.github.io/inertia-django/guide/ page leads to https://inertiajs.github.io/inertia-django/guide/ again in a loop. 

I fixed it, now it leads to the next page according to the sidebar which is https://inertiajs.github.io/inertia-django/guide/server-side-setup