### PR TITLE
Integrate Django flash messages into Inertia page props

### DIFF
--- a/inertia/http.py
+++ b/inertia/http.py
@@ -4,6 +4,7 @@ from http import HTTPStatus
 from json import dumps as json_encode
 from typing import Any, Callable
 
+from django.contrib.messages import get_messages
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest, HttpResponse
 from django.template.loader import render_to_string
@@ -112,7 +113,16 @@ class BaseInertiaResponseMixin:
                 if isinstance(_props[key], IgnoreOnFirstLoadProp):
                     del _props[key]
 
-        return deep_transform_callables(_props)
+        _props = deep_transform_callables(_props)
+
+        flash = [
+            {"level": m.level_tag, "message": str(m)}
+            for m in get_messages(self.request)
+        ]
+        if flash:
+            _props["messages"] = flash
+
+        return _props
 
     def build_deferred_props(self) -> dict[str, Any] | None:
         if self.request.is_a_partial_render(self.component):

--- a/inertia/tests/test_messages.py
+++ b/inertia/tests/test_messages.py
@@ -1,0 +1,24 @@
+from inertia.test import InertiaTestCase
+
+
+class FlashMessagesTestCase(InertiaTestCase):
+    def test_success_message_included_in_props(self):
+        self.inertia.get("/messages/")
+        self.assertIncludesProps({
+            "messages": [{"level": "success", "message": "Profile saved!"}]
+        })
+
+    def test_no_messages_key_when_no_messages(self):
+        self.inertia.get("/no-messages/")
+        self.assertNotIn("messages", self.props())
+
+    def test_messages_consumed_after_render(self):
+        # First request — message should be present
+        self.inertia.get("/messages/")
+        self.assertIncludesProps({
+            "messages": [{"level": "success", "message": "Profile saved!"}]
+        })
+
+        # Second request to a view with no messages — should not carry over
+        self.inertia.get("/no-messages/")
+        self.assertNotIn("messages", self.props())

--- a/inertia/tests/testapp/urls.py
+++ b/inertia/tests/testapp/urls.py
@@ -23,4 +23,6 @@ urlpatterns = [
     path("clear-history/", views.clear_history_test),
     path("clear-history-redirect/", views.clear_history_redirect_test),
     path("clear-history-type-error/", views.clear_history_type_error_test),
+    path("messages/", views.messages_test),
+    path("no-messages/", views.no_messages_test),
 ]

--- a/inertia/tests/testapp/views.py
+++ b/inertia/tests/testapp/views.py
@@ -1,3 +1,4 @@
+from django.contrib import messages
 from django.http.response import HttpResponse
 from django.shortcuts import redirect
 from django.utils.decorators import decorator_from_middleware
@@ -151,4 +152,15 @@ def clear_history_redirect_test(request):
 @inertia("TestComponent")
 def clear_history_type_error_test(request):
     request.session[INERTIA_SESSION_CLEAR_HISTORY] = "foo"
+    return {}
+
+
+@inertia("TestComponent")
+def messages_test(request):
+    messages.success(request, "Profile saved!")
+    return {}
+
+
+@inertia("TestComponent")
+def no_messages_test(request):
     return {}


### PR DESCRIPTION
## Summary
- Integrated Django's built-in flash messages framework into the
  Inertia response cycle so messages are automatically available
  as page props on the frontend
- Messages are added after partial render filtering to prevent
  permanent message loss on partial page requests
- Messages key is omitted entirely when no messages exist, keeping
  props clean

## Motivation
Fixes Issue #38

In a standard Django app, flash messages set via `messages.success()`,
`messages.error()` etc. are consumed by the template layer. Since
Inertia bypasses Django templates and communicates entirely through
JSON props, these messages were silently lost — they were never
included in the Inertia response, so the frontend had no way to
display them.

## Changes
- `inertia/http.py`: Import `get_messages` and add flash messages to
  props inside `build_props()`, after the partial render filtering step
- `inertia/tests/testapp/views.py`: Add `messages_test` and
  `no_messages_test` views for testing
- `inertia/tests/testapp/urls.py`: Register the two new test URLs
- `inertia/tests/test_messages.py`: 3 tests covering message inclusion,
  empty props behavior, and message consumption after render

## Frontend Usage
Once merged, flash messages are available in props automatically:

```js
// React / Vue / Svelte
const { messages } = usePage().props

// Each message has:
// { level: "success" | "error" | "warning" | "info", message: "..." }