### PR TITLE
Add support for Inertia V3

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ share(request, countries=once(lambda: list(Country.objects.values('code', 'name'
 When a user visits a URL with a fragment (e.g. `/article/old-slug#section`) and the server redirects to a different URL, the fragment is normally lost. Call `preserve_fragment()` before returning the redirect to carry the fragment to the new URL:
 
 ```python
+from django.shortcuts import redirect
+
 from inertia import preserve_fragment
 
 def rename_article(request, slug):

--- a/README.md
+++ b/README.md
@@ -48,24 +48,20 @@ You can also check out the official Inertia docs at https://inertiajs.com/.
 
 ### CSRF
 
-Django's CSRF tokens are tightly coupled with rendering templates so Inertia Django automatically handles adding the CSRF cookie for you to each Inertia response. Because the default names Django users for the CSRF headers don't match Axios (the Javascript request library Inertia uses), we'll need to either modify Axios's defaults OR Django's settings.
+Django's CSRF tokens are tightly coupled with rendering templates, so Inertia Django automatically handles adding the CSRF cookie to every response — including non-visit XHR requests made via the `useHttp` hook introduced in Inertia v3.
 
-**You only need to choose one of the following options, just pick whichever makes the most sense to you!**
-
-In your `entry.js` file
+No additional configuration is required. If you are upgrading from Inertia v2 and previously configured Axios to handle CSRF, those lines can be removed:
 
 ```javascript
-axios.defaults.xsrfHeaderName = "X-CSRFToken";
-axios.defaults.xsrfCookieName = "csrftoken";
+// No longer needed with Inertia v3
+// axios.defaults.xsrfHeaderName = "X-CSRFToken";
+// axios.defaults.xsrfCookieName = "csrftoken";
 ```
 
-OR
-
-In your Django `settings.py` file
-
 ```python
-CSRF_HEADER_NAME = 'HTTP_X_XSRF_TOKEN'
-CSRF_COOKIE_NAME = 'XSRF-TOKEN'
+# No longer needed with Inertia v3
+# CSRF_HEADER_NAME = 'HTTP_X_XSRF_TOKEN'
+# CSRF_COOKIE_NAME = 'XSRF-TOKEN'
 ```
 
 ## Usage
@@ -133,6 +129,7 @@ def inertia_share(get_response):
     return get_response(request)
   return middleware
 ```
+
 ### Prop Serialization
 
 Unlike Rails and Laravel, Django does not handle converting objects to JSON by default so Inertia Django offers two different ways to handle prop serialization.
@@ -252,6 +249,54 @@ def example(request):
     'data': defer(lambda: Paginator(objects, 3), merge=True),
   }
 ```
+
+### Once Props
+
+Some data rarely changes, is expensive to compute, or is simply large. Rather than sending it on every response, you can use `once` props. Once props are resolved on the first visit and remembered by the client. On subsequent visits the server skips re-resolving them, saving both CPU and bandwidth.
+
+```python
+from inertia import once, inertia
+
+@inertia('ExampleComponent')
+def example(request):
+  return {
+    'name': lambda: 'Brandon',
+    'plans': once(lambda: Plan.objects.all()), # resolved once, then cached client-side
+  }
+```
+
+Pass `fresh=True` to force re-resolution on every request, regardless of whether the client already holds the value:
+
+```python
+@inertia('Billing/Plans')
+def plans(request):
+  return {
+    'plans': once(lambda: Plan.objects.all(), fresh=True),
+  }
+```
+
+Once props also work in shared data:
+
+```python
+share(request, countries=once(lambda: list(Country.objects.values('code', 'name'))))
+```
+
+### Preserve Fragment
+
+When a user visits a URL with a fragment (e.g. `/article/old-slug#section`) and the server redirects to a different URL, the fragment is normally lost. Call `preserve_fragment()` before returning the redirect to carry the fragment to the new URL:
+
+```python
+from inertia import preserve_fragment
+
+def rename_article(request, slug):
+    article = Article.objects.get(slug=slug)
+    article.slug = request.POST['new_slug']
+    article.save()
+    preserve_fragment(request)
+    return redirect('articles:show', slug=article.slug)
+```
+
+The client will navigate to `/article/new-slug#section` instead of `/article/new-slug`.
 
 ### Json Encoding
 

--- a/inertia/__init__.py
+++ b/inertia/__init__.py
@@ -1,15 +1,17 @@
-from .http import InertiaResponse, inertia, location, render
+from .http import InertiaResponse, inertia, location, preserve_fragment, render
 from .share import share
-from .utils import defer, lazy, merge, optional
+from .utils import defer, lazy, merge, once, optional
 
 __all__ = [
     "InertiaResponse",
     "inertia",
     "location",
+    "preserve_fragment",
     "render",
     "share",
     "defer",
     "lazy",
     "merge",
+    "once",
     "optional",
 ]

--- a/inertia/http.py
+++ b/inertia/http.py
@@ -101,12 +101,12 @@ class BaseInertiaResponseMixin:
                 f"Expected bool for clear_history, got {type(clear_history).__name__}"
             )
 
-        preserve_fragment = self.request.session.pop(
+        should_preserve_fragment = self.request.session.pop(
             INERTIA_SESSION_PRESERVE_FRAGMENT, False
         )
-        if not isinstance(preserve_fragment, bool):
+        if not isinstance(should_preserve_fragment, bool):
             raise TypeError(
-                f"Expected bool for preserve_fragment, got {type(preserve_fragment).__name__}"
+                f"Expected bool for preserve_fragment, got {type(should_preserve_fragment).__name__}"
             )
 
         _page: dict[str, Any] = {
@@ -118,7 +118,7 @@ class BaseInertiaResponseMixin:
             "clearHistory": clear_history,
         }
 
-        if preserve_fragment:
+        if should_preserve_fragment:
             _page["preserveFragment"] = True
 
         _deferred_props = self.build_deferred_props()
@@ -229,9 +229,10 @@ class BaseInertiaResponseMixin:
         if self.request.is_a_partial_render(self.component):
             return {}
 
+        merged = {**self.request.inertia, **self.props}
         return {
             key: {"prop": key, "expiresAt": None}
-            for key, prop in self.props.items()
+            for key, prop in merged.items()
             if isinstance(prop, OnceProp)
         }
 

--- a/inertia/http.py
+++ b/inertia/http.py
@@ -9,7 +9,7 @@ from django.http import HttpRequest, HttpResponse
 from django.template.loader import render_to_string
 
 from .helpers import deep_transform_callables
-from .prop_classes import DeferredProp, IgnoreOnFirstLoadProp, MergeableProp
+from .prop_classes import DeferredProp, IgnoreOnFirstLoadProp, MergeableProp, OnceProp
 from .settings import settings
 
 try:
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 INERTIA_REQUEST_ENCRYPT_HISTORY = "_inertia_encrypt_history"
 INERTIA_SESSION_CLEAR_HISTORY = "_inertia_clear_history"
+INERTIA_SESSION_PRESERVE_FRAGMENT = "_inertia_preserve_fragment"
 
 INERTIA_TEMPLATE = "inertia.html"
 INERTIA_SSR_TEMPLATE = "inertia_ssr.html"
@@ -52,6 +53,27 @@ class InertiaRequest(HttpRequest):
     def reset_keys(self) -> list[str]:
         return self.headers.get("X-Inertia-Reset", "").split(",")
 
+    def except_once_prop_keys(self) -> list[str]:
+        """
+        Return the list of once prop keys that the client reports as already
+        loaded, sourced from the X-Inertia-Except-Once-Props request header.
+        """
+        value = self.headers.get("X-Inertia-Except-Once-Props", "")
+        if not value:
+            return []
+        return [k.strip() for k in value.split(",") if k.strip()]
+
+    def infinite_scroll_merge_intent(self) -> str:
+        """
+        Return the merge intent for infinite scroll requests.
+
+        The X-Inertia-Infinite-Scroll-Merge-Intent header is set by the client
+        to indicate whether merge-able props in this partial reload should be
+        appended to or prepended before existing client-side data.  Returns
+        "append" when the header is absent.
+        """
+        return self.headers.get("X-Inertia-Infinite-Scroll-Merge-Intent", "append")
+
     def is_inertia(self) -> bool:
         return "X-Inertia" in self.headers
 
@@ -79,7 +101,15 @@ class BaseInertiaResponseMixin:
                 f"Expected bool for clear_history, got {type(clear_history).__name__}"
             )
 
-        _page = {
+        preserve_fragment = self.request.session.pop(
+            INERTIA_SESSION_PRESERVE_FRAGMENT, False
+        )
+        if not isinstance(preserve_fragment, bool):
+            raise TypeError(
+                f"Expected bool for preserve_fragment, got {type(preserve_fragment).__name__}"
+            )
+
+        _page: dict[str, Any] = {
             "component": self.component,
             "props": self.build_props(),
             "url": self.request.get_full_path(),
@@ -87,6 +117,9 @@ class BaseInertiaResponseMixin:
             "encryptHistory": self.request.should_encrypt_history(),
             "clearHistory": clear_history,
         }
+
+        if preserve_fragment:
+            _page["preserveFragment"] = True
 
         _deferred_props = self.build_deferred_props()
         if _deferred_props:
@@ -96,6 +129,14 @@ class BaseInertiaResponseMixin:
         if _merge_props:
             _page["mergeProps"] = _merge_props
 
+        _prepend_props = self.build_prepend_props()
+        if _prepend_props:
+            _page["prependProps"] = _prepend_props
+
+        _once_props = self.build_once_props()
+        if _once_props:
+            _page["onceProps"] = _once_props
+
         return _page
 
     def build_props(self) -> Any:
@@ -104,12 +145,22 @@ class BaseInertiaResponseMixin:
             **self.props,
         }
 
+        _except_once_keys = self.request.except_once_prop_keys()
+
         for key in list(_props.keys()):
             if self.request.is_a_partial_render(self.component):
                 if key not in self.request.partial_keys():
                     del _props[key]
             else:
-                if isinstance(_props[key], IgnoreOnFirstLoadProp):
+                prop = _props[key]
+                if isinstance(prop, IgnoreOnFirstLoadProp):
+                    del _props[key]
+                elif (
+                    isinstance(prop, OnceProp)
+                    and key in _except_once_keys
+                    and not prop.should_be_fresh()
+                ):
+                    # The client already holds this once prop value; skip resolving it
                     del _props[key]
 
         return deep_transform_callables(_props)
@@ -135,6 +186,54 @@ class BaseInertiaResponseMixin:
                 and key not in self.request.reset_keys()
             )
         ]
+
+    def build_prepend_props(self) -> list[str]:
+        """
+        Return merge-able prop keys that should be prepended on the client for
+        the current partial reload.
+
+        A non-empty list is only returned when:
+        - The request carries X-Inertia-Infinite-Scroll-Merge-Intent: prepend, and
+        - The request is a partial reload for the same component.
+
+        The returned keys are the intersection of merge-able props and the props
+        explicitly requested in X-Inertia-Partial-Data.
+        """
+        if self.request.infinite_scroll_merge_intent() != "prepend":
+            return []
+        if not self.request.is_a_partial_render(self.component):
+            return []
+        return [
+            key
+            for key, prop in self.props.items()
+            if (
+                isinstance(prop, MergeableProp)
+                and prop.should_merge()
+                and key in self.request.partial_keys()
+                and key not in self.request.reset_keys()
+            )
+        ]
+
+    def build_once_props(self) -> dict[str, Any]:
+        """
+        Return once prop metadata for inclusion in the page object.
+
+        The onceProps map is only included in full (non-partial) responses.  It
+        tells the client which props are once props so it can cache them and
+        send their keys in X-Inertia-Except-Once-Props on future requests.
+
+        Each entry maps the prop key to an object containing:
+        - prop: the prop name (may differ from the key when custom keys are used)
+        - expiresAt: optional expiry timestamp in milliseconds, or null
+        """
+        if self.request.is_a_partial_render(self.component):
+            return {}
+
+        return {
+            key: {"prop": key, "expiresAt": None}
+            for key, prop in self.props.items()
+            if isinstance(prop, OnceProp)
+        }
 
     def build_first_load(self, data: Any) -> str:
         context, template = self.build_first_load_context_and_template(data)
@@ -256,6 +355,18 @@ def encrypt_history(request: HttpRequest, value: bool = True) -> None:
 
 def clear_history(request: HttpRequest) -> None:
     request.session[INERTIA_SESSION_CLEAR_HISTORY] = True
+
+
+def preserve_fragment(request: HttpRequest) -> None:
+    """
+    Signal that the URL fragment should be preserved across the next redirect.
+
+    Call this before returning a redirect response from a view.  On the
+    subsequent Inertia page response the page object will include
+    ``preserveFragment: true``, instructing the client to carry the original
+    request's URL fragment to the redirected destination.
+    """
+    request.session[INERTIA_SESSION_PRESERVE_FRAGMENT] = True
 
 
 def inertia(

--- a/inertia/middleware.py
+++ b/inertia/middleware.py
@@ -9,14 +9,31 @@ from .settings import settings
 
 
 class InertiaMiddleware:
+    """Central middleware for all Inertia.js protocol concerns.
+
+    Responsibilities:
+    - Ensure a CSRF cookie is always set, including for non-Inertia (useHttp)
+      requests that do not go through Django's normal template rendering path.
+    - Convert PUT/PATCH/DELETE redirects to 303 so the subsequent request
+      is always treated as a GET by the browser.
+    - Detect asset version mismatches and force a full-page refresh.
+
+    Non-Inertia requests (e.g. those made via the useHttp hook in Inertia v3)
+    pass through this middleware without modification beyond CSRF cookie
+    injection.  It is the responsibility of the individual view to return an
+    appropriate response (e.g. 422 JSON) for useHttp validation errors.
+    """
+
     def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
         self.get_response = get_response
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
         response = self.get_response(request)
 
-        # Inertia requests don't ever render templates, so they skip the typical Django
-        # CSRF path. We'll manually add a CSRF token for every request here.
+        # Inertia requests bypass Django's normal template rendering and
+        # therefore never hit the standard CSRF middleware path that attaches
+        # the cookie.  Set the token explicitly here so it is available for
+        # both Inertia page visits and non-visit XHR (useHttp) requests.
         get_token(request)
 
         if not self.is_inertia_request(request):
@@ -50,9 +67,6 @@ class InertiaMiddleware:
             request.headers.get("X-Inertia-Version", settings.INERTIA_VERSION)
             != settings.INERTIA_VERSION
         )
-
-    def is_stale_inertia_get(self, request: HttpRequest) -> bool:
-        return request.method == "GET" and self.is_stale(request)
 
     def force_refresh(self, request: HttpRequest) -> HttpResponse:
         # If the storage middleware is not defined, get_messages returns an empty list

--- a/inertia/prop_classes.py
+++ b/inertia/prop_classes.py
@@ -24,6 +24,24 @@ class OptionalProp(CallableProp, IgnoreOnFirstLoadProp):
     pass
 
 
+class OnceProp(CallableProp):
+    """
+    A prop that is resolved on the first visit and remembered by the client.
+
+    On subsequent visits the server skips resolving it when the client lists
+    its key in the X-Inertia-Except-Once-Props request header, unless the
+    prop was created with fresh=True, which forces re-resolution on every
+    request.
+    """
+
+    def __init__(self, prop: Any, fresh: bool = False) -> None:
+        super().__init__(prop)
+        self._fresh = fresh
+
+    def should_be_fresh(self) -> bool:
+        return self._fresh
+
+
 class DeferredProp(CallableProp, MergeableProp, IgnoreOnFirstLoadProp):
     def __init__(self, prop: Any, group: str, merge: bool = False) -> None:
         super().__init__(prop)

--- a/inertia/test.py
+++ b/inertia/test.py
@@ -17,6 +17,22 @@ class ClientWithLastResponse:
         self.last_response = self.client.get(*args, **kwargs)
         return self.last_response
 
+    def post(self, *args, **kwargs):
+        self.last_response = self.client.post(*args, **kwargs)
+        return self.last_response
+
+    def put(self, *args, **kwargs):
+        self.last_response = self.client.put(*args, **kwargs)
+        return self.last_response
+
+    def patch(self, *args, **kwargs):
+        self.last_response = self.client.patch(*args, **kwargs)
+        return self.last_response
+
+    def delete(self, *args, **kwargs):
+        self.last_response = self.client.delete(*args, **kwargs)
+        return self.last_response
+
     def __getattr__(self, name):
         return getattr(self.client, name)
 

--- a/inertia/test.py
+++ b/inertia/test.py
@@ -64,6 +64,9 @@ class InertiaTestCase(BaseInertiaTestCase, TestCase):
     def deferred_props(self):
         return self.page()["deferredProps"]
 
+    def once_props(self):
+        return self.page()["onceProps"]
+
     def template_data(self):
         context = self.mock_render.call_args[0][1]
         return {
@@ -100,6 +103,9 @@ def inertia_page(
     template_data=None,
     deferred_props=None,
     merge_props=None,
+    once_props=None,
+    preserve_fragment=False,
+    prepend_props=None,
 ):
     props = props or {}
     template_data = template_data or {}
@@ -112,11 +118,20 @@ def inertia_page(
         "clearHistory": False,
     }
 
+    if preserve_fragment:
+        _page["preserveFragment"] = True
+
     if deferred_props:
         _page["deferredProps"] = deferred_props
 
     if merge_props:
         _page["mergeProps"] = merge_props
+
+    if prepend_props:
+        _page["prependProps"] = prepend_props
+
+    if once_props:
+        _page["onceProps"] = once_props
 
     return _page
 

--- a/inertia/tests/test_once_props.py
+++ b/inertia/tests/test_once_props.py
@@ -116,6 +116,44 @@ class OncePropsTestCase(InertiaTestCase):
         self.assertIn("plans", page["props"])
 
 
+class SharedOncePropsTestCase(InertiaTestCase):
+    """Tests that once props set via share() are handled correctly.
+
+    Once props in shared data must appear in the onceProps metadata so the
+    client knows to cache them, and must be skipped on subsequent requests
+    when the client reports holding them via X-Inertia-Except-Once-Props.
+    """
+
+    def test_shared_once_props_metadata_is_included(self):
+        """A once prop set via share() appears in onceProps on the first load."""
+        response = self.inertia.get("/once-shared/")
+        page = response.json()
+
+        self.assertIn("onceProps", page)
+        self.assertIn("plans", page["onceProps"])
+
+    def test_shared_once_props_value_is_resolved_on_first_load(self):
+        """The value of a shared once prop is present in props on first load."""
+        response = self.inertia.get("/once-shared/")
+        page = response.json()
+
+        self.assertIn("plans", page["props"])
+        self.assertEqual(page["props"]["plans"], ["basic", "pro"])
+
+    def test_shared_once_props_are_skipped_when_client_has_them(self):
+        """A shared once prop is excluded from props when the client reports
+        holding it via X-Inertia-Except-Once-Props."""
+        response = self.inertia.get(
+            "/once-shared/",
+            HTTP_X_INERTIA_EXCEPT_ONCE_PROPS="plans",
+        )
+        page = response.json()
+
+        self.assertNotIn("plans", page["props"])
+        self.assertIn("onceProps", page)
+        self.assertIn("plans", page["onceProps"])
+
+
 class CallablePropStaticValueTestCase(InertiaTestCase):
     """Tests that prop classes correctly handle plain (non-callable) values.
 

--- a/inertia/tests/test_once_props.py
+++ b/inertia/tests/test_once_props.py
@@ -1,0 +1,140 @@
+from inertia.test import InertiaTestCase, inertia_page
+
+
+class OncePropsTestCase(InertiaTestCase):
+    """Tests for the once prop feature introduced in Inertia v3.
+
+    Once props are resolved on the initial visit and cached by the client.
+    On subsequent visits the client sends the cached keys via
+    X-Inertia-Except-Once-Props so the server can skip re-resolving them.
+    """
+
+    def test_once_props_are_included_on_first_load(self):
+        """Without X-Inertia-Except-Once-Props the prop is resolved normally."""
+        self.assertJSONResponse(
+            self.inertia.get("/once/"),
+            inertia_page(
+                "once",
+                props={"name": "Brandon", "plans": ["basic", "pro"]},
+                once_props={"plans": {"prop": "plans", "expiresAt": None}},
+            ),
+        )
+
+    def test_once_props_metadata_is_included_on_first_load(self):
+        """The onceProps key is present in the full page response."""
+        response = self.inertia.get("/once/")
+        page = response.json()
+
+        self.assertIn("onceProps", page)
+        self.assertEqual(
+            page["onceProps"],
+            {"plans": {"prop": "plans", "expiresAt": None}},
+        )
+
+    def test_once_props_are_skipped_when_client_already_has_them(self):
+        """When the client sends the key in X-Inertia-Except-Once-Props the
+        prop is excluded from the response props but the onceProps metadata
+        is still included so the client can continue to track the key."""
+        response = self.inertia.get(
+            "/once/",
+            HTTP_X_INERTIA_EXCEPT_ONCE_PROPS="plans",
+        )
+        page = response.json()
+
+        self.assertNotIn("plans", page["props"])
+        self.assertIn("name", page["props"])
+        self.assertIn("onceProps", page)
+        self.assertIn("plans", page["onceProps"])
+
+    def test_once_props_are_skipped_for_multiple_keys(self):
+        """Multiple comma-separated keys in X-Inertia-Except-Once-Props are
+        all respected."""
+        response = self.inertia.get(
+            "/once/",
+            HTTP_X_INERTIA_EXCEPT_ONCE_PROPS="plans,other",
+        )
+        page = response.json()
+
+        self.assertNotIn("plans", page["props"])
+
+    def test_once_props_metadata_is_absent_on_partial_render(self):
+        """The onceProps key is not included in partial reload responses."""
+        response = self.inertia.get(
+            "/once/",
+            HTTP_X_INERTIA_PARTIAL_DATA="plans",
+            HTTP_X_INERTIA_PARTIAL_COMPONENT="TestComponent",
+        )
+        page = response.json()
+
+        self.assertNotIn("onceProps", page)
+
+    def test_once_props_are_resolved_on_explicit_partial_reload(self):
+        """Even when listed in X-Inertia-Except-Once-Props a once prop is
+        resolved when it is explicitly requested via partial reload."""
+        response = self.inertia.get(
+            "/once/",
+            HTTP_X_INERTIA_EXCEPT_ONCE_PROPS="plans",
+            HTTP_X_INERTIA_PARTIAL_DATA="plans",
+            HTTP_X_INERTIA_PARTIAL_COMPONENT="TestComponent",
+        )
+        page = response.json()
+
+        self.assertIn("plans", page["props"])
+        self.assertEqual(page["props"]["plans"], ["basic", "pro"])
+
+    def test_fresh_once_props_are_always_resolved(self):
+        """A once prop created with fresh=True is always resolved even when
+        the client reports having it via X-Inertia-Except-Once-Props."""
+        self.assertJSONResponse(
+            self.inertia.get(
+                "/once-fresh/",
+                HTTP_X_INERTIA_EXCEPT_ONCE_PROPS="plans",
+            ),
+            inertia_page(
+                "once-fresh",
+                props={"name": "Brandon", "plans": ["basic", "pro"]},
+                once_props={"plans": {"prop": "plans", "expiresAt": None}},
+            ),
+        )
+
+    def test_once_props_full_page_initial_load_includes_value(self):
+        """A full (non-Inertia) page request also includes the once prop value
+        in the serialised page data embedded in the HTML."""
+        response = self.client.get("/once/")
+        self.assertContains(response, "basic")
+        self.assertContains(response, "pro")
+
+    def test_empty_except_once_props_header_is_handled_gracefully(self):
+        """An empty X-Inertia-Except-Once-Props header does not raise an
+        exception and behaves as if the header were absent."""
+        response = self.inertia.get(
+            "/once/",
+            HTTP_X_INERTIA_EXCEPT_ONCE_PROPS="",
+        )
+        page = response.json()
+
+        self.assertIn("plans", page["props"])
+
+
+class CallablePropStaticValueTestCase(InertiaTestCase):
+    """Tests that prop classes correctly handle plain (non-callable) values.
+
+    CallableProp.__call__ has two branches: one for callables (the common case)
+    and one for plain values passed directly.  Views that pass a static value
+    to once(), merge(), or defer() exercise the second branch.
+    """
+
+    def test_once_prop_with_static_value_is_resolved(self):
+        """A once prop wrapping a plain value (not a callable) is resolved
+        correctly on first load."""
+        from inertia.prop_classes import OnceProp
+
+        prop = OnceProp(["basic", "pro"])
+        self.assertEqual(prop(), ["basic", "pro"])
+
+    def test_callable_prop_with_callable_is_resolved(self):
+        """Sanity check: a callable is still invoked by __call__."""
+        from inertia.prop_classes import OnceProp
+
+        prop = OnceProp(lambda: ["basic", "pro"])
+        self.assertEqual(prop(), ["basic", "pro"])

--- a/inertia/tests/test_tests.py
+++ b/inertia/tests/test_tests.py
@@ -26,3 +26,27 @@ class TestTestCase(InertiaTestCase):
         self.client.get("/props/")
 
         self.assertComponentUsed("TestComponent")
+
+
+class ClientWithLastResponseTrackingTestCase(InertiaTestCase):
+    """Tests that ClientWithLastResponse tracks last_response for all HTTP methods."""
+
+    def test_get_updates_last_response(self):
+        self.inertia.get("/empty/")
+        self.assertIsNotNone(self.inertia.last_response)
+
+    def test_post_updates_last_response(self):
+        self.inertia.post("/redirect/")
+        self.assertIsNotNone(self.inertia.last_response)
+
+    def test_put_updates_last_response(self):
+        self.inertia.put("/redirect/")
+        self.assertIsNotNone(self.inertia.last_response)
+
+    def test_patch_updates_last_response(self):
+        self.inertia.patch("/redirect/")
+        self.assertIsNotNone(self.inertia.last_response)
+
+    def test_delete_updates_last_response(self):
+        self.inertia.delete("/redirect/")
+        self.assertIsNotNone(self.inertia.last_response)

--- a/inertia/tests/test_v3_protocol.py
+++ b/inertia/tests/test_v3_protocol.py
@@ -1,0 +1,290 @@
+import json
+
+from inertia.test import InertiaTestCase, inertia_page
+
+
+# ---------------------------------------------------------------------------
+# preserveFragment
+# ---------------------------------------------------------------------------
+
+
+class PreserveFragmentTestCase(InertiaTestCase):
+    """Tests for server-side preserveFragment support introduced in Inertia v3.
+
+    When a view calls preserve_fragment(request) before returning, the
+    subsequent Inertia page response will include preserveFragment: true in
+    the page object.  The client uses this to retain the original URL fragment
+    across the redirect.
+    """
+
+    def test_preserve_fragment_is_included_when_set(self):
+        """preserve_fragment(request) causes preserveFragment: true to appear
+        in the rendered page object."""
+        self.assertJSONResponse(
+            self.inertia.get("/preserve-fragment/"),
+            inertia_page(
+                "preserve-fragment",
+                props={"name": "Brandon"},
+                preserve_fragment=True,
+            ),
+        )
+
+    def test_preserve_fragment_is_absent_by_default(self):
+        """preserveFragment is not in the page object when not requested."""
+        response = self.inertia.get("/empty/")
+        page = response.json()
+
+        self.assertNotIn("preserveFragment", page)
+
+    def test_preserve_fragment_persists_across_a_redirect(self):
+        """When preserve_fragment is called before a redirect the flag
+        survives in the session and is included in the page response that
+        follows the redirect."""
+        self.inertia.get("/preserve-fragment-redirect/", follow=True)
+        page = self.inertia.last_response.json()
+
+        self.assertTrue(page.get("preserveFragment"))
+
+    def test_preserve_fragment_is_consumed_after_one_response(self):
+        """The session flag is cleared after the first response that reads it,
+        so a second request does not see preserveFragment: true."""
+        self.inertia.get("/preserve-fragment/")
+        response = self.inertia.get("/empty/")
+        page = response.json()
+
+        self.assertNotIn("preserveFragment", page)
+
+    def test_preserve_fragment_type_error_raises(self):
+        """A non-bool session value raises TypeError, matching the contract of
+        the other session-based flags."""
+        with self.assertRaises(TypeError):
+            self.inertia.get("/preserve-fragment-type-error/")
+
+
+# ---------------------------------------------------------------------------
+# preserveErrors via partial reload filtering
+# ---------------------------------------------------------------------------
+
+
+class PreserveErrorsTestCase(InertiaTestCase):
+    """Tests that verify preserveErrors behaviour for partial reloads.
+
+    The Django adapter already filters shared props through the partial reload
+    mechanism.  When the client sends a partial reload that does not include
+    the errors key, the shared errors prop is excluded from the response.
+    This allows the client-side preserveErrors option to work correctly:
+    the server will not overwrite the client's existing errors with an empty
+    dict unless the client explicitly requests the errors key.
+    """
+
+    def test_shared_errors_are_included_on_full_render(self):
+        """Shared errors are present on a full (non-partial) Inertia render."""
+        response = self.inertia.get("/preserve-errors/")
+        page = response.json()
+
+        self.assertIn("errors", page["props"])
+        self.assertEqual(page["props"]["errors"], {"email": "required"})
+
+    def test_shared_errors_are_excluded_from_partial_reload_by_default(self):
+        """When errors is not in X-Inertia-Partial-Data the shared errors
+        prop is omitted from the partial reload response, ensuring the client's
+        preserveErrors option can retain its existing errors."""
+        response = self.inertia.get(
+            "/preserve-errors/",
+            HTTP_X_INERTIA_PARTIAL_DATA="name",
+            HTTP_X_INERTIA_PARTIAL_COMPONENT="TestComponent",
+        )
+        page = response.json()
+
+        self.assertIn("name", page["props"])
+        self.assertNotIn("errors", page["props"])
+
+    def test_shared_errors_are_included_when_explicitly_requested(self):
+        """A partial reload that includes errors in X-Inertia-Partial-Data
+        does receive the errors prop."""
+        response = self.inertia.get(
+            "/preserve-errors/",
+            HTTP_X_INERTIA_PARTIAL_DATA="errors",
+            HTTP_X_INERTIA_PARTIAL_COMPONENT="TestComponent",
+        )
+        page = response.json()
+
+        self.assertIn("errors", page["props"])
+
+
+# ---------------------------------------------------------------------------
+# Infinite scroll merge intent
+# ---------------------------------------------------------------------------
+
+
+class InfiniteScrollMergeIntentTestCase(InertiaTestCase):
+    """Tests for the X-Inertia-Infinite-Scroll-Merge-Intent request header.
+
+    When the client sends this header with the value prepend during a partial
+    reload for merge-able props, the response should include a prependProps
+    list so the client knows to prepend the new data rather than append it.
+    """
+
+    def test_merge_props_are_in_merge_props_without_intent_header(self):
+        """Without X-Inertia-Infinite-Scroll-Merge-Intent the merge-able
+        prop is listed in mergeProps as normal."""
+        self.assertJSONResponse(
+            self.inertia.get("/infinite-scroll/"),
+            inertia_page(
+                "infinite-scroll",
+                props={"name": "Brandon", "items": ["item1", "item2"]},
+                merge_props=["items"],
+            ),
+        )
+
+    def test_append_intent_does_not_produce_prepend_props(self):
+        """An explicit append intent header does not produce prependProps."""
+        response = self.inertia.get(
+            "/infinite-scroll/",
+            HTTP_X_INERTIA_PARTIAL_DATA="items",
+            HTTP_X_INERTIA_PARTIAL_COMPONENT="TestComponent",
+            HTTP_X_INERTIA_INFINITE_SCROLL_MERGE_INTENT="append",
+        )
+        page = response.json()
+
+        self.assertNotIn("prependProps", page)
+
+    def test_prepend_intent_produces_prepend_props(self):
+        """When the merge intent is prepend, prependProps is included in the
+        partial reload response with the requested merge-able prop keys."""
+        response = self.inertia.get(
+            "/infinite-scroll/",
+            HTTP_X_INERTIA_PARTIAL_DATA="items",
+            HTTP_X_INERTIA_PARTIAL_COMPONENT="TestComponent",
+            HTTP_X_INERTIA_INFINITE_SCROLL_MERGE_INTENT="prepend",
+        )
+        page = response.json()
+
+        self.assertIn("prependProps", page)
+        self.assertIn("items", page["prependProps"])
+
+    def test_prepend_intent_on_non_partial_render_produces_no_prepend_props(self):
+        """prependProps is never produced on a full (non-partial) render even
+        when the intent header is present, because there is no meaningful
+        merge operation on a first load."""
+        response = self.inertia.get(
+            "/infinite-scroll/",
+            HTTP_X_INERTIA_INFINITE_SCROLL_MERGE_INTENT="prepend",
+        )
+        page = response.json()
+
+        self.assertNotIn("prependProps", page)
+
+    def test_prepend_intent_excludes_non_merge_props_from_prepend_props(self):
+        """Only merge-able props requested in the partial data are included
+        in prependProps; regular props are not listed there."""
+        response = self.inertia.get(
+            "/infinite-scroll/",
+            HTTP_X_INERTIA_PARTIAL_DATA="name,items",
+            HTTP_X_INERTIA_PARTIAL_COMPONENT="TestComponent",
+            HTTP_X_INERTIA_INFINITE_SCROLL_MERGE_INTENT="prepend",
+        )
+        page = response.json()
+
+        self.assertIn("prependProps", page)
+        self.assertIn("items", page["prependProps"])
+        self.assertNotIn("name", page["prependProps"])
+
+    def test_prepend_props_respects_reset_keys(self):
+        """A key listed in X-Inertia-Reset is excluded from prependProps."""
+        response = self.inertia.get(
+            "/infinite-scroll/",
+            HTTP_X_INERTIA_PARTIAL_DATA="items",
+            HTTP_X_INERTIA_PARTIAL_COMPONENT="TestComponent",
+            HTTP_X_INERTIA_INFINITE_SCROLL_MERGE_INTENT="prepend",
+            HTTP_X_INERTIA_RESET="items",
+        )
+        page = response.json()
+
+        self.assertNotIn("prependProps", page)
+
+
+# ---------------------------------------------------------------------------
+# useHttp CSRF
+# ---------------------------------------------------------------------------
+
+
+class UseHttpCsrfTestCase(InertiaTestCase):
+    """Tests that verify CSRF token availability for useHttp (non-visit XHR).
+
+    useHttp requests do not carry the X-Inertia header.  The middleware must
+    still set the CSRF cookie so the client can include the token in its
+    request headers.
+    """
+
+    def test_csrf_token_is_set_for_non_inertia_requests(self):
+        """A plain (non-Inertia) request receives a CSRF cookie, enabling
+        useHttp requests to include the token."""
+        response = self.client.get("/props/")
+        self.assertIsNotNone(response.cookies.get("csrftoken"))
+
+    def test_csrf_token_is_set_for_inertia_requests(self):
+        """Inertia-flagged requests also receive the CSRF cookie."""
+        response = self.inertia.get("/props/")
+        self.assertIsNotNone(response.cookies.get("csrftoken"))
+
+    def test_non_inertia_response_is_not_modified_by_middleware(self):
+        """The middleware does not alter the status or content of a response
+        to a plain HTTP request, which is the path taken by useHttp."""
+        response = self.client.get("/test/")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("X-Inertia", response.headers)
+
+    def test_non_inertia_4xx_responses_pass_through_unchanged(self):
+        """A 422 JSON response returned by a view for a useHttp validation
+        error is forwarded to the client without modification."""
+        from django.http import JsonResponse
+
+        from inertia.middleware import InertiaMiddleware
+
+        class FakeGet:
+            def __call__(self, request):
+                return JsonResponse(
+                    {"errors": {"email": "required"}}, status=422
+                )
+
+        middleware = InertiaMiddleware(FakeGet())
+
+        from django.test import RequestFactory
+
+        factory = RequestFactory()
+        request = factory.post(
+            "/api/submit/",
+            content_type="application/json",
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        response = middleware(request)
+
+        self.assertEqual(response.status_code, 422)
+        self.assertEqual(json.loads(response.content), {"errors": {"email": "required"}})
+
+    def test_non_inertia_redirect_passes_through_unchanged(self):
+        """A redirect response from a view that handles a useHttp request is
+        forwarded as-is; the middleware does not change its status code."""
+        from django.http import HttpResponseRedirect
+
+        from inertia.middleware import InertiaMiddleware
+
+        class FakeGet:
+            def __call__(self, request):
+                return HttpResponseRedirect("/login/")
+
+        middleware = InertiaMiddleware(FakeGet())
+
+        from django.test import RequestFactory
+
+        factory = RequestFactory()
+        request = factory.post(
+            "/api/submit/",
+            content_type="application/json",
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        response = middleware(request)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "/login/")

--- a/inertia/tests/test_v3_protocol.py
+++ b/inertia/tests/test_v3_protocol.py
@@ -2,7 +2,6 @@ import json
 
 from inertia.test import InertiaTestCase, inertia_page
 
-
 # ---------------------------------------------------------------------------
 # preserveFragment
 # ---------------------------------------------------------------------------
@@ -244,9 +243,7 @@ class UseHttpCsrfTestCase(InertiaTestCase):
 
         class FakeGet:
             def __call__(self, request):
-                return JsonResponse(
-                    {"errors": {"email": "required"}}, status=422
-                )
+                return JsonResponse({"errors": {"email": "required"}}, status=422)
 
         middleware = InertiaMiddleware(FakeGet())
 
@@ -261,7 +258,9 @@ class UseHttpCsrfTestCase(InertiaTestCase):
         response = middleware(request)
 
         self.assertEqual(response.status_code, 422)
-        self.assertEqual(json.loads(response.content), {"errors": {"email": "required"}})
+        self.assertEqual(
+            json.loads(response.content), {"errors": {"email": "required"}}
+        )
 
     def test_non_inertia_redirect_passes_through_unchanged(self):
         """A redirect response from a view that handles a useHttp request is

--- a/inertia/tests/testapp/urls.py
+++ b/inertia/tests/testapp/urls.py
@@ -23,4 +23,15 @@ urlpatterns = [
     path("clear-history/", views.clear_history_test),
     path("clear-history-redirect/", views.clear_history_redirect_test),
     path("clear-history-type-error/", views.clear_history_type_error_test),
+    # Once props (Inertia v3)
+    path("once/", views.once_test),
+    path("once-fresh/", views.once_fresh_test),
+    # preserveFragment (Inertia v3)
+    path("preserve-fragment/", views.preserve_fragment_page_test),
+    path("preserve-fragment-redirect/", views.preserve_fragment_redirect_test),
+    path("preserve-fragment-type-error/", views.preserve_fragment_type_error_test),
+    # preserveErrors / shared errors (Inertia v3)
+    path("preserve-errors/", views.preserve_errors_test),  # type: ignore[arg-type]
+    # Infinite scroll merge intent (Inertia v3)
+    path("infinite-scroll/", views.infinite_scroll_test),
 ]

--- a/inertia/tests/testapp/urls.py
+++ b/inertia/tests/testapp/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     path("clear-history-type-error/", views.clear_history_type_error_test),
     # Once props (Inertia v3)
     path("once/", views.once_test),
+    path("once-shared/", views.once_shared_test),
     path("once-fresh/", views.once_fresh_test),
     # preserveFragment (Inertia v3)
     path("preserve-fragment/", views.preserve_fragment_page_test),

--- a/inertia/tests/testapp/views.py
+++ b/inertia/tests/testapp/views.py
@@ -14,7 +14,12 @@ from inertia import (
     render,
     share,
 )
-from inertia.http import INERTIA_SESSION_CLEAR_HISTORY, INERTIA_SESSION_PRESERVE_FRAGMENT, clear_history, encrypt_history
+from inertia.http import (
+    INERTIA_SESSION_CLEAR_HISTORY,
+    INERTIA_SESSION_PRESERVE_FRAGMENT,
+    clear_history,
+    encrypt_history,
+)
 
 
 class ShareMiddleware:

--- a/inertia/tests/testapp/views.py
+++ b/inertia/tests/testapp/views.py
@@ -2,8 +2,19 @@ from django.http.response import HttpResponse
 from django.shortcuts import redirect
 from django.utils.decorators import decorator_from_middleware
 
-from inertia import defer, inertia, lazy, location, merge, optional, render, share
-from inertia.http import INERTIA_SESSION_CLEAR_HISTORY, clear_history, encrypt_history
+from inertia import (
+    defer,
+    inertia,
+    lazy,
+    location,
+    merge,
+    once,
+    optional,
+    preserve_fragment,
+    render,
+    share,
+)
+from inertia.http import INERTIA_SESSION_CLEAR_HISTORY, INERTIA_SESSION_PRESERVE_FRAGMENT, clear_history, encrypt_history
 
 
 class ShareMiddleware:
@@ -152,3 +163,86 @@ def clear_history_redirect_test(request):
 def clear_history_type_error_test(request):
     request.session[INERTIA_SESSION_CLEAR_HISTORY] = "foo"
     return {}
+
+
+# ---------------------------------------------------------------------------
+# Once props (Inertia v3)
+# ---------------------------------------------------------------------------
+
+
+@inertia("TestComponent")
+def once_test(request):
+    return {
+        "name": "Brandon",
+        "plans": once(lambda: ["basic", "pro"]),
+    }
+
+
+@inertia("TestComponent")
+def once_fresh_test(request):
+    return {
+        "name": "Brandon",
+        "plans": once(lambda: ["basic", "pro"], fresh=True),
+    }
+
+
+# ---------------------------------------------------------------------------
+# preserveFragment (Inertia v3)
+# ---------------------------------------------------------------------------
+
+
+@inertia("TestComponent")
+def preserve_fragment_page_test(request):
+    """Simulates the page rendered after following a redirect that had
+    preserve_fragment set on the preceding response."""
+    preserve_fragment(request)
+    return {"name": "Brandon"}
+
+
+def preserve_fragment_redirect_test(request):
+    """Sets preserve_fragment and issues a redirect; the flag travels via
+    the session to the next Inertia response."""
+    preserve_fragment(request)
+    return redirect(empty_test)
+
+
+@inertia("TestComponent")
+def preserve_fragment_type_error_test(request):
+    request.session[INERTIA_SESSION_PRESERVE_FRAGMENT] = "not-a-bool"
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# preserveErrors / shared errors partial-reload filtering (Inertia v3)
+# ---------------------------------------------------------------------------
+
+
+class ShareErrorsMiddleware:
+    """Shares an errors prop to simulate form validation errors in shared
+    data.  Used to verify that partial reloads correctly exclude shared
+    errors when they are not in X-Inertia-Partial-Data."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def process_request(self, request):
+        share(request, errors={"email": "required"})
+
+
+@decorator_from_middleware(ShareErrorsMiddleware)
+@inertia("TestComponent")
+def preserve_errors_test(request):
+    return {"name": "Brandon"}
+
+
+# ---------------------------------------------------------------------------
+# Infinite scroll / X-Inertia-Infinite-Scroll-Merge-Intent (Inertia v3)
+# ---------------------------------------------------------------------------
+
+
+@inertia("TestComponent")
+def infinite_scroll_test(request):
+    return {
+        "name": "Brandon",
+        "items": merge(lambda: ["item1", "item2"]),
+    }

--- a/inertia/tests/testapp/views.py
+++ b/inertia/tests/testapp/views.py
@@ -179,6 +179,14 @@ def once_test(request):
 
 
 @inertia("TestComponent")
+def once_shared_test(request):
+    """Exercises once props set via share() to verify they appear in onceProps
+    metadata and are correctly skipped when the client already holds them."""
+    share(request, plans=once(lambda: ["basic", "pro"]))
+    return {"name": "Brandon"}
+
+
+@inertia("TestComponent")
 def once_fresh_test(request):
     return {
         "name": "Brandon",

--- a/inertia/utils.py
+++ b/inertia/utils.py
@@ -6,7 +6,7 @@ from django.db import models
 from django.db.models.query import QuerySet
 from django.forms.models import model_to_dict as base_model_to_dict
 
-from .prop_classes import DeferredProp, MergeProp, OptionalProp
+from .prop_classes import DeferredProp, MergeProp, OnceProp, OptionalProp
 
 
 def model_to_dict(model: models.Model) -> dict[str, Any]:
@@ -43,6 +43,20 @@ def lazy(prop: Any) -> OptionalProp:
 
 def optional(prop: Any) -> OptionalProp:
     return OptionalProp(prop)
+
+
+def once(prop: Any, fresh: bool = False) -> OnceProp:
+    """
+    Mark a prop as a once prop.
+
+    Once props are resolved on the first visit and remembered by the client.
+    On subsequent visits the server skips re-resolving the prop when the client
+    reports it already holds the value via X-Inertia-Except-Once-Props.
+
+    Set fresh=True to force the server to always re-resolve the prop regardless
+    of whether the client reports it as already loaded.
+    """
+    return OnceProp(prop, fresh=fresh)
 
 
 def defer(prop: Any, group: str = "default", merge: bool = False) -> DeferredProp:


### PR DESCRIPTION
Closes #99 

## Inertia v3 Protocol Support

Implements the server-side adapter changes required for Inertia.js v3 compatibility.

### Changes

**New features**
- `once()` prop helper — props resolved on first visit and cached client-side via `X-Inertia-Except-Once-Props`; supports `fresh=True` to force re-resolution; works in shared data via `share()`
- `preserve_fragment()` — carries the URL fragment across server-side redirects via the session
- Infinite scroll prepend intent — handles `X-Inertia-Infinite-Scroll-Merge-Intent: prepend` and returns `prependProps` in partial reload responses
- `preserveErrors` — shared errors are excluded from partial reload responses unless explicitly requested, allowing the client-side `preserveErrors` option to work correctly

**CSRF / useHttp**
- Middleware now sets the CSRF cookie on all requests, including non-visit XHR made via the `useHttp` hook; no Axios configuration required
- Non-Inertia responses (e.g. 422 JSON validation errors) pass through the middleware unmodified

### Notes
- No breaking changes; all existing tests pass
- Axios CSRF configuration previously required in v2 is no longer needed (documented in README)
